### PR TITLE
Refactor PDF pre-processing into a SageMaker Processing Job

### DIFF
--- a/annotation/__init__.py
+++ b/annotation/__init__.py
@@ -87,14 +87,14 @@ class AnnotationInfra(cdk.Construct):
                                 "ecr:DescribeRepositories",
                                 "ecr:UploadLayerPart",
                                 "ecr:ListImages",
-                                "ecr:InitiateLayerUpload", 
+                                "ecr:InitiateLayerUpload",
                                 "ecr:BatchCheckLayerAvailability",
                                 "ecr:PutImage",
                             ],
                             effect=Effect.ALLOW,
                             resources=[
                                 # We'll only allow a specific repo name, rather than any default:
-                                #"arn:aws:ecr:*:*:repository/sagemaker-studio*",
+                                # "arn:aws:ecr:*:*:repository/sagemaker-studio*",
                                 "arn:aws:ecr:*:*:repository/sm-scikit-ocrtools",
                             ],
                         ),
@@ -138,7 +138,6 @@ class AnnotationInfra(cdk.Construct):
                         #     effect=Effect.ALLOW,
                         #     resources=["arn:aws:s3:::sagemaker*"],
                         # ),
-
                         # Only required if not explicitly passing a --role (which we will):
                         # PolicyStatement(
                         #     sid="LookUpIAMRoles",
@@ -146,7 +145,6 @@ class AnnotationInfra(cdk.Construct):
                         #     effect=Effect.ALLOW,
                         #     resources=["*"],
                         # ),
-
                         # Only required if building within VPCs (which we won't):
                         # PolicyStatement(
                         #     sid="VPCAccess",
@@ -165,7 +163,7 @@ class AnnotationInfra(cdk.Construct):
                         # ),
                     ],
                 ),
-            }
+            },
         )
 
         self.lambda_role = Role(
@@ -223,8 +221,7 @@ class AnnotationInfra(cdk.Construct):
         return self._post_lambda
 
     def get_data_science_policy_statements(self) -> List[PolicyStatement]:
-        """Generate policy statements required for data scientist to use the annotation infra
-        """
+        """Generate policy statements required for data scientist to use the annotation infra"""
         return [
             PolicyStatement(
                 sid="PassSMImageBuildRole",

--- a/notebooks/1. Data Preparation.ipynb
+++ b/notebooks/1. Data Preparation.ipynb
@@ -35,7 +35,11 @@
    "source": [
     "## Getting started: Dependencies and configuration\n",
     "\n",
-    "First there are some additional libraries we need to install that aren't present in the SageMaker kernel environments by default:"
+    "First there are some additional libraries we need to install that aren't present in the SageMaker kernel environments by default:\n",
+    "\n",
+    "- [Amazon Textract Response Parser](https://github.com/aws-samples/amazon-textract-response-parser) is a helper for interpreting and navigating Amazon Textract result JSON.\n",
+    "- The [SageMaker Studio Image Build CLI](https://github.com/aws-samples/sagemaker-studio-image-build-cli) is a tool for building customized container images and pushing to [Amazon ECR](https://aws.amazon.com/ecr/).\n",
+    "- [SageMaker Python SDK](https://sagemaker.readthedocs.io/en/stable/) (installed by default in SageMaker already) must be version >=2.49 for the Hugging Face container versions used in notebook 2."
    ]
   },
   {
@@ -46,32 +50,9 @@
    },
    "outputs": [],
    "source": [
-    "# Tool for building customized container images and pushing to Amazon ECR:\n",
-    "!pip install sagemaker-studio-image-build"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "# Helper for interpreting Textract results:\n",
-    "!pip install amazon-textract-response-parser"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "# Notebook 2 requires sagemaker>=2.49 for Hugging Face container versions:\n",
-    "!pip install \"sagemaker>=2.49,<3\""
+    "!pip install amazon-textract-response-parser \\\n",
+    "    sagemaker-studio-image-build \\\n",
+    "    \"sagemaker>=2.49,<3\""
    ]
   },
   {
@@ -657,18 +638,16 @@
     "\n",
     "Therefore instead of pre-processing the raw documents here in the notebook, this is a good use case for a scalable [SageMaker Processing Job](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html).\n",
     "\n",
-    "First, our processing job will require a base container image to work with. The PDF reading tools we use aren't installed by default in pre-built SageMaker containers and aren't `pip install`able, so below we use the [SageMaker Studio Image Build CLI](https://github.com/aws-samples/sagemaker-studio-image-build-cli) to build a customized image based on the SageMaker Scikit-Learn container and upload it to the [Amazon Elastic Container Registry (ECR)](https://aws.amazon.com/ecr/):"
+    "First, our processing job will require a base **container image** to work with. The PDF reading tools we use aren't installed by default in pre-built SageMaker containers and aren't `pip install`able, so below we use the [SageMaker Studio Image Build CLI](https://github.com/aws-samples/sagemaker-studio-image-build-cli) to build a customized image based on the SageMaker Scikit-Learn container and upload it to the [Amazon Elastic Container Registry (ECR)](https://aws.amazon.com/ecr/):"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
+    "# Configurations:\n",
     "ecr_repo_name = \"sm-scikit-ocrtools\"\n",
     "ecr_image_tag = \"pytorch-1.7-cpu\"\n",
     "\n",
@@ -681,17 +660,38 @@
     "    version=\"1.7\",\n",
     ")\n",
     "\n",
-    "!sm-docker build ./preproc \\\n",
-    "    --repository {ecr_repo_name}:{ecr_image_tag} \\\n",
-    "    --role {config.sm_image_build_role} \\\n",
-    "    --build-arg BASE_IMAGE={base_image_uri}\n",
-    "\n",
-    "# Since the above is a shell command, we'll need to reconstruct the built URI here in Python too:\n",
+    "# Combine together into the final URI (not needed for the build, but used later in the notebook):\n",
     "account_id = sagemaker.Session().account_id()\n",
     "region = os.environ[\"AWS_REGION\"]\n",
     "ecr_image_uri = f\"{account_id}.dkr.ecr.{region}.amazonaws.com/{ecr_repo_name}:{ecr_image_tag}\"\n",
+    "print(f\"Will build to {ecr_image_uri}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# (No need to re-run this cell if your image is already in ECR)\n",
     "\n",
-    "# Check from Python the image was successfully created:\n",
+    "# Actually build & push the container image:\n",
+    "!sm-docker build ./preproc \\\n",
+    "    --repository {ecr_repo_name}:{ecr_image_tag} \\\n",
+    "    --role {config.sm_image_build_role} \\\n",
+    "    --build-arg BASE_IMAGE={base_image_uri}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check from notebook whether the image was successfully created:\n",
     "ecr = boto3.client(\"ecr\")\n",
     "imgs_desc = ecr.describe_images(\n",
     "    registryId=account_id,\n",
@@ -705,7 +705,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we need to define the inputs for the processing job.\n",
+    "Next, we need to **define the inputs** for the processing job.\n",
     "\n",
     "To process the whole `data/raw` corpus, you could simply pass the whole `data/raw` prefix in S3 as input to the job (As shown in the commented-out *Option 2* below) and scale up the `instance_count` to complete the work quickly.\n",
     "\n",
@@ -726,8 +726,8 @@
     "\n",
     "#### OPTION 1: For processing the rel_filepaths_sample subset of raw docs only:\n",
     "# Prepare a manifest file:\n",
-    "os.makedirs(\"data/preproc\", exist_ok=True)\n",
-    "preproc_input_manifest_path = \"data/preproc/dataclean-input.manifest.json\"\n",
+    "os.makedirs(\"data/manifests\", exist_ok=True)\n",
+    "preproc_input_manifest_path = \"data/manifests/raw-dataclean-input.manifest.json\"\n",
     "with open(preproc_input_manifest_path, \"w\") as f:\n",
     "    f.write(json.dumps(\n",
     "        [{ \"prefix\": raw_s3uri + \"/\" }]\n",
@@ -771,6 +771,8 @@
     "The script we'll be using to process the documents is in the same folder as the Dockerfile used earlier to build the container image: [preproc/imgclean.py](preproc/imageclean.py).\n",
     "\n",
     "The code parallelizes processing across available CPUs, and the `ShardedByS3Key` setting used on our [ProcessingInput](https://sagemaker.readthedocs.io/en/stable/api/training/processing.html#sagemaker.processing.ProcessingInput) above distributes documents between instances if muliple are provided - so you should be able to `instance_type` and `instance_count` of the job if needed to take advantage of what resources you have available. The process is typically CPU-bound, so the `ml.c*` families are likely a good fit.\n",
+    "\n",
+    "The cell below will **run the processing job** and show logs from the job as it progresses. You can also check up on the status and history of jobs in the [Processing page of the Amazon SageMaker Console](https://console.aws.amazon.com/sagemaker/home?#/processing-jobs).\n",
     "\n",
     "> ⏰ **Note:** In our tests, it took (including job start-up overheads):\n",
     ">\n",

--- a/notebooks/1. Data Preparation.ipynb
+++ b/notebooks/1. Data Preparation.ipynb
@@ -46,9 +46,8 @@
    },
    "outputs": [],
    "source": [
-    "# Tool for splitting PDFs into SMGT-ready images:\n",
-    "!conda install -c conda-forge poppler -y\n",
-    "!pip install pdf2image"
+    "# Tool for building customized container images and pushing to Amazon ECR:\n",
+    "!pip install sagemaker-studio-image-build"
    ]
   },
   {
@@ -620,9 +619,13 @@
    "source": [
     "### Extract clean input images\n",
     "\n",
-    "Generally, EXIF rotation metadata will not be applied to images displayed in SageMaker Ground Truth at the time of writing. The utility function below will clean a dataset of images and/or PDFs for use with SMGT: Extracting page images from PDFs, and fixing the EXIF rotation of any images.\n",
+    "To annotate our documents with SageMaker Ground Truth image task UIs, we need **individual page images**, stripped of EXIF rotation metadata (because, at the time of writing, SMGT ignores this rotation for annotation consistency) and converted to compatible formats (since some browsers cannot render certain formats - such as TIFF).\n",
     "\n",
-    "> ⏰ **Note:** The utility function below has not been heavily optimized and may still take ~30mins to run against a 120-document sample of the dataset. For large-scale processing, you could consider porting the code to a multi-instance [SageMaker Processing Job](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html)"
+    "For large corpora this process of splitting PDFs and rotating and converting images may require significant resources, but is easy to parallelize.\n",
+    "\n",
+    "Therefore instead of pre-processing the raw documents here in the notebook, this is a good use case for a scalable [SageMaker Processing Job](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html).\n",
+    "\n",
+    "First, our processing job will require a base container image to work with. The PDF reading tools we use aren't installed by default in pre-built SageMaker containers and aren't `pip install`able, so below we use the [SageMaker Studio Image Build CLI](https://github.com/aws-samples/sagemaker-studio-image-build-cli) to build a customized image based on the SageMaker Scikit-Learn container and upload it to the [Amazon Elastic Container Registry (ECR)](https://aws.amazon.com/ecr/):"
    ]
   },
   {
@@ -633,17 +636,147 @@
    },
    "outputs": [],
    "source": [
-    "_ = util.preproc.clean_dataset_for_img_ocr(\n",
-    "    \"data/raw\",\n",
-    "    \"data/imgs-clean\",\n",
-    "    # Comment-out the `filepaths` line below to process the entire dataset:\n",
-    "    filepaths=rel_filepaths_sample,\n",
+    "%%time\n",
+    "ecr_repo_name = \"sm-scikit-ocrtools\"\n",
+    "ecr_image_tag = \"pytorch-1.7-cpu\"\n",
     "\n",
-    "    # Default params:\n",
-    "    # pdf_dpi=300,\n",
-    "    # pdf_image_format=\"png\",\n",
-    "    # textract_compatible_formats=(\"jpg\", \"jpeg\", \"png\"),\n",
-    "    # preferred_image_format=\"png\",\n",
+    "base_image_uri = sagemaker.image_uris.retrieve(\n",
+    "    framework=\"pytorch\",\n",
+    "    region=os.environ[\"AWS_REGION\"],\n",
+    "    instance_type=\"ml.c5.xlarge\",  # (Just used to check whether GPUs/accelerators are used)\n",
+    "    py_version=\"py3\",\n",
+    "    image_scope=\"training\",\n",
+    "    version=\"1.7\",\n",
+    ")\n",
+    "\n",
+    "!sm-docker build ./preproc \\\n",
+    "    --repository {ecr_repo_name}:{ecr_image_tag} \\\n",
+    "    --role {config.sm_image_build_role} \\\n",
+    "    --build-arg BASE_IMAGE={base_image_uri}\n",
+    "\n",
+    "# Since the above is a shell command, we'll need to reconstruct the built URI here in Python too:\n",
+    "account_id = sagemaker.Session().account_id()\n",
+    "region = os.environ[\"AWS_REGION\"]\n",
+    "ecr_image_uri = f\"{account_id}.dkr.ecr.{region}.amazonaws.com/{ecr_repo_name}:{ecr_image_tag}\"\n",
+    "\n",
+    "# Check from Python the image was successfully created:\n",
+    "ecr = boto3.client(\"ecr\")\n",
+    "imgs_desc = ecr.describe_images(\n",
+    "    registryId=account_id,\n",
+    "    repositoryName=ecr_repo_name,\n",
+    "    imageIds=[{ \"imageTag\": ecr_image_tag }],\n",
+    ")\n",
+    "assert len(imgs_desc[\"imageDetails\"]) > 0, f\"Couldn't find ECR image {ecr_image_uri} after build\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we need to define the inputs for the processing job.\n",
+    "\n",
+    "To process the whole `data/raw` corpus, you could simply pass the whole `data/raw` prefix in S3 as input to the job (As shown in the commented-out *Option 2* below) and scale up the `instance_count` to complete the work quickly.\n",
+    "\n",
+    "To process just a sample subset of files for speed in our demo, we'll create a **manifest file** listing just the documents we want.\n",
+    "\n",
+    "> ⚠️ **Note:** 'Non-augmented' manifest files are still JSON-based, but a different format from the other dataset manifests we'll be using through this sample. You can find guidance for manifests as used here on the [S3DataSource API doc](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_S3DataSource.html), and separate information on the \"augmented\" manifests as used later with SageMaker Ground Truth in the [Ground Truth documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/sms-input-data-input-manifest.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.processing import ProcessingInput, ProcessingOutput, ScriptProcessor\n",
+    "\n",
+    "imgs_s3uri = f\"s3://{bucket_name}/{bucket_prefix}data/imgs-clean\"\n",
+    "\n",
+    "#### OPTION 1: For processing the rel_filepaths_sample subset of raw docs only:\n",
+    "# Prepare a manifest file:\n",
+    "os.makedirs(\"data/preproc\", exist_ok=True)\n",
+    "preproc_input_manifest_path = \"data/preproc/dataclean-input.manifest.json\"\n",
+    "with open(preproc_input_manifest_path, \"w\") as f:\n",
+    "    f.write(json.dumps(\n",
+    "        [{ \"prefix\": raw_s3uri + \"/\" }]\n",
+    "        + rel_filepaths_sample\n",
+    "    ))\n",
+    "\n",
+    "# Upload the manifest to S3:\n",
+    "preproc_input_manifest_s3uri = f\"s3://{bucket_name}/{bucket_prefix}{preproc_input_manifest_path}\"\n",
+    "!aws s3 cp {preproc_input_manifest_path} {preproc_input_manifest_s3uri}\n",
+    "\n",
+    "# Set the processing job inputs to reference the manifest:\n",
+    "preproc_inputs = [\n",
+    "    ProcessingInput(\n",
+    "        destination=\"/opt/ml/processing/input/raw\",  # Expected input location, per our script\n",
+    "        input_name=\"raw\",\n",
+    "        s3_data_distribution_type=\"ShardedByS3Key\",  # Distribute between instances, if multiple\n",
+    "        s3_data_type=\"ManifestFile\",\n",
+    "        source=preproc_input_manifest_s3uri,  # Manifest of sample raw documents\n",
+    "    ),\n",
+    "]\n",
+    "print(\"Selected sample subset of documents\")\n",
+    "#### END OPTION 1\n",
+    "\n",
+    "#### OPTION 2: For processing the whole data/raw folder:\n",
+    "# preproc_inputs = [\n",
+    "#     ProcessingInput(\n",
+    "#         destination=\"/opt/ml/processing/input/raw\",  # Expected input location, per our script\n",
+    "#         input_name=\"raw\",\n",
+    "#         s3_data_distribution_type=\"ShardedByS3Key\",  # Distribute between instances, if multiple\n",
+    "#         source=raw_s3uri,  # S3 prefix for full raw document collection\n",
+    "#     ),\n",
+    "# ]\n",
+    "# print(\"Selected whole corpus\")\n",
+    "#### END OPTION 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The script we'll be using to process the documents is in the same folder as the Dockerfile used earlier to build the container image: [preproc/imgclean.py](preproc/imageclean.py).\n",
+    "\n",
+    "The code parallelizes processing across available CPUs, and the `ShardedByS3Key` setting used on our [ProcessingInput](https://sagemaker.readthedocs.io/en/stable/api/training/processing.html#sagemaker.processing.ProcessingInput) above distributes documents between instances if muliple are provided - so you should be able to `instance_type` and `instance_count` of the job if needed to take advantage of what resources you have available. The process is typically CPU-bound, so the `ml.c*` families are likely a good fit.\n",
+    "\n",
+    "> ⏰ **Note:** In our tests, it took (including job start-up overheads):\n",
+    ">\n",
+    "> - About 9 minutes to process the 120-document sample with 2x `ml.c5.xlarge` instances\n",
+    "> - About 17 minutes to process the full 2,541-document corpus with 5x `ml.c5.4xlarge` instances."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "processor = ScriptProcessor(\n",
+    "    base_job_name=\"ocr-img-dataclean\",\n",
+    "    command=[\"python3\"],\n",
+    "    image_uri=ecr_image_uri,  # As created above\n",
+    "    instance_count=2,\n",
+    "    instance_type=\"ml.c5.xlarge\",\n",
+    "    max_runtime_in_seconds=60*60,\n",
+    "    role=sagemaker.get_execution_role(),\n",
+    "    volume_size_in_gb=15,\n",
+    ")\n",
+    "\n",
+    "processor.run(\n",
+    "    code=\"preproc/imgclean.py\",  # PDF splitting / image conversion script\n",
+    "    inputs=preproc_inputs,  # Either whole corpus or sample, as above\n",
+    "    outputs=[\n",
+    "        ProcessingOutput(\n",
+    "            destination=imgs_s3uri,\n",
+    "            output_name=\"imgs-clean\",\n",
+    "            s3_upload_mode=\"Continuous\",\n",
+    "            source=\"/opt/ml/processing/output/imgs-clean\",  # Output folder, per our script\n",
+    "        )\n",
+    "    ],\n",
     ")"
    ]
   },
@@ -651,7 +784,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once these images have been extracted, they'll also need to be loaded to S3 to use in Amazon SageMaker Ground Truth:"
+    "Once the images have been extracted, we'll also download them locally to the notebook for use in visualizations later:"
    ]
   },
   {
@@ -660,17 +793,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imgs_s3uri = f\"s3://{bucket_name}/{bucket_prefix}data/imgs-clean\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(f\"Uploading cleaned images to {imgs_s3uri}...\")\n",
-    "!aws s3 sync --quiet data/imgs-clean $imgs_s3uri\n",
+    "print(f\"Downloading cleaned images from {imgs_s3uri}...\")\n",
+    "!aws s3 sync --quiet {imgs_s3uri} data/imgs-clean\n",
     "print(\"Done\")"
    ]
   },

--- a/notebooks/1. Data Preparation.ipynb
+++ b/notebooks/1. Data Preparation.ipynb
@@ -707,11 +707,11 @@
    "source": [
     "Next, we need to **define the inputs** for the processing job.\n",
     "\n",
-    "To process the whole `data/raw` corpus, you could simply pass the whole `data/raw` prefix in S3 as input to the job (As shown in the commented-out *Option 2* below) and scale up the `instance_count` to complete the work quickly.\n",
+    "To process the whole `data/raw` corpus, you could simply pass the whole `data/raw` prefix in S3 as input to the job (As shown in the commented-out *Option 2* below) and scale up the job's compute resources to complete the work quickly.\n",
     "\n",
     "To process just a sample subset of files for speed in our demo, we'll create a **manifest file** listing just the documents we want.\n",
     "\n",
-    "> ⚠️ **Note:** 'Non-augmented' manifest files are still JSON-based, but a different format from the other dataset manifests we'll be using through this sample. You can find guidance for manifests as used here on the [S3DataSource API doc](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_S3DataSource.html), and separate information on the \"augmented\" manifests as used later with SageMaker Ground Truth in the [Ground Truth documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/sms-input-data-input-manifest.html)."
+    "> ⚠️ **Note:** 'Non-augmented' manifest files are still JSON-based, but a different format from the other dataset manifests we'll be using through this sample. You can find guidance on the [S3DataSource API doc](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_S3DataSource.html) for manifests as used here, and separate information in the [Ground Truth documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/sms-input-data-input-manifest.html) on the \"augmented\" manifests as used later with SageMaker Ground Truth."
    ]
   },
   {
@@ -768,9 +768,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The script we'll be using to process the documents is in the same folder as the Dockerfile used earlier to build the container image: [preproc/imgclean.py](preproc/imageclean.py).\n",
+    "The script we'll be using to process the documents is in the same folder as the Dockerfile used earlier to build the container image: [preproc/imgclean.py](preproc/imgclean.py).\n",
     "\n",
-    "The code parallelizes processing across available CPUs, and the `ShardedByS3Key` setting used on our [ProcessingInput](https://sagemaker.readthedocs.io/en/stable/api/training/processing.html#sagemaker.processing.ProcessingInput) above distributes documents between instances if muliple are provided - so you should be able to `instance_type` and `instance_count` of the job if needed to take advantage of what resources you have available. The process is typically CPU-bound, so the `ml.c*` families are likely a good fit.\n",
+    "The code parallelizes processing across available CPUs, and the `ShardedByS3Key` setting used on our [ProcessingInput](https://sagemaker.readthedocs.io/en/stable/api/training/processing.html#sagemaker.processing.ProcessingInput) above distributes documents between instances if multiple are provided. This means you should be able to adjust both `instance_type` and `instance_count` below, and still take advantage of the resources configured. The process is typically CPU-bound, so the `ml.c*` families are likely a good fit.\n",
     "\n",
     "The cell below will **run the processing job** and show logs from the job as it progresses. You can also check up on the status and history of jobs in the [Processing page of the Amazon SageMaker Console](https://console.aws.amazon.com/sagemaker/home?#/processing-jobs).\n",
     "\n",

--- a/notebooks/2. Model Training.ipynb
+++ b/notebooks/2. Model Training.ipynb
@@ -709,8 +709,28 @@
    "source": [
     "## Using the Model\n",
     "\n",
-    "Once the deployment is complete, we're ready to try it out with some real-time requests!\n",
-    "\n",
+    "Once the deployment is complete, we're ready to try it out with some real-time requests!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# As with estimators, you can attach the notebook to a previously deployed endpoint like this:\n",
+    "# from sagemaker.huggingface import HuggingFacePredictor\n",
+    "# predictor = HuggingFacePredictor(\n",
+    "#     \"layoutlm-cfpb-hf-2021-09-02-01-08-11-234\",\n",
+    "#     serializer=sagemaker.serializers.JSONSerializer(),\n",
+    "#     deserializer=sagemaker.deserializers.JSONDeserializer(),\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Making requests and rendering results\n",
     "\n",
     "This model accepts Textract-like JSON (e.g. as returned by [AnalyzeDocument](https://docs.aws.amazon.com/textract/latest/dg/API_AnalyzeDocument.html#API_AnalyzeDocument_ResponseSyntax) or [DetectDocumentText](https://docs.aws.amazon.com/textract/latest/dg/API_DetectDocumentText.html#API_DetectDocumentText_ResponseSyntax) APIs) and classifies each `WORD` [block](https://docs.aws.amazon.com/textract/latest/dg/API_Block.html) according to the entity classes we defined earlier: Returning the same JSON with additional fields added to indicate the predictions.\n",

--- a/notebooks/preproc/Dockerfile
+++ b/notebooks/preproc/Dockerfile
@@ -1,0 +1,10 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Container image with document/image processing tools added.
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+RUN conda install -c conda-forge poppler -y \
+  && pip install amazon-textract-response-parser pdf2image "Pillow>=8,<9"

--- a/notebooks/preproc/__init__.py
+++ b/notebooks/preproc/__init__.py
@@ -1,0 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# This file is not necessary for the processing job, but provided in case you want to `import`
+# scripts in this folder from the notebooks to experiment.

--- a/notebooks/preproc/imgclean.py
+++ b/notebooks/preproc/imgclean.py
@@ -1,0 +1,232 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""SageMaker Processing script to prepare raw documents into SMGT-ready page images
+"""
+
+# Python Built-Ins:
+import argparse
+import json
+import logging
+from multiprocessing import cpu_count, Pool
+import os
+import shutil
+import time
+from types import SimpleNamespace
+from typing import Iterable, List, Optional
+
+logging.basicConfig(level="INFO", format="%(asctime)s %(name)s [%(levelname)s] %(message)s")
+
+# External Dependencies:
+import pdf2image
+import PIL
+from PIL import ExifTags
+
+
+logger = logging.getLogger("preproc")
+
+
+def split_filename(filename):
+    basename, _, ext = filename.rpartition(".")
+    return basename, ext
+
+
+class ImageExtractionResult:
+    """Result descriptor for extracting a source image/document to image(s)"""
+
+    def __init__(self, rawpath: str, cleanpaths: List[str] = [], cats: List[str] = []):
+        self.rawpath = rawpath
+        self.cleanpaths = cleanpaths
+        self.cats = cats
+
+
+def clean_dataset_for_img_ocr(
+    from_path: str,
+    to_path: str,
+    filepaths: Optional[Iterable[str]] = None,
+    pdf_dpi: int = 300,
+    pdf_image_format: str = "png",
+    textract_compatible_formats: Iterable[str] = ("jpg", "jpeg", "png"),
+    preferred_image_format: str = "png",
+) -> List[ImageExtractionResult]:
+    """Process a mixed PDF/image dataset for use with SageMaker Ground Truth image task UIs
+
+    Extracts page images from PDFs, converts EXIF-rotated images to data-rotated.
+
+    Parameters
+    ----------
+    from_path : str
+        Base path of the raw/source dataset to be converted
+    to_path : str
+        Target path for converted files (subfolder structure will be preserved from source)
+    filepaths : Optional[Iterable[str]]
+        Paths (relative to from_path, no leading slash) to filter down the processing. If not
+        provided, the whole from_path folder will be recursively crawled.
+    pdf_dpi : int
+        DPI resolution to extract images from PDFs (Default 300).
+    pdf_image_format : str
+        Format to extract images from PDFs (Default 'png').
+    textract_compatible_formats : Iterable[str]
+        The set of compatible file formats for Textract: Used to determine whether to convert
+        source images in other formats which PIL may still have been able to successfully load.
+    preferred_image_format : str
+        Format to be used when an image has been saved/converted (Default 'png').
+    """
+    results = []
+    if filepaths:
+        # Users will supply relative filepaths, but our code below expects to include from_path:
+        filepaths = [os.path.join(from_path, p) for p in filepaths]
+    else:
+        # List input files automatically by walking the from_path dir:
+        filepaths = list(
+            filter(
+                lambda path: "/." not in path,  # Ignore hidden stuff e.g. .ipynb_checkpoints
+                (os.path.join(path, f) for path, _, files in os.walk(from_path) for f in files),
+            )
+        )
+    n_files_total = len(filepaths)
+    os.makedirs(to_path, exist_ok=True)
+
+    for ixfilepath, filepath in enumerate(filepaths):
+        # TODO: Would be better to have global progress logging than per-worker
+        logger.debug("Doc %s of %s", ixfilepath + 1, len(filepaths))
+        # Because we use all available cores, things can become unhappy if we don't provide a
+        # little breathing space for any background procesess:
+        time.sleep(0.5)
+        
+        filename = os.path.basename(filepath)
+        subfolder = os.path.dirname(filepath)[len(from_path) :]  # Includes leading slash!
+        outfolder = to_path + subfolder
+        os.makedirs(outfolder, exist_ok=True)
+        basename, ext = split_filename(filename)
+        ext_lower = ext.lower()
+        result = ImageExtractionResult(
+            rawpath=filepath,
+            cleanpaths=[],
+            cats=subfolder[1:].split(os.path.sep),  # Strip leading slash to avoid initial ''
+        )
+        if ext_lower == "pdf":
+            logger.info(
+                "Converting {} to {}/{}*.{}".format(
+                    filepath,
+                    outfolder,
+                    basename + "-",
+                    pdf_image_format,
+                )
+            )
+            images = pdf2image.convert_from_path(
+                filepath,
+                output_folder=outfolder,
+                output_file=basename + "-",
+                # TODO: Use paths_only option to return paths instead of image objs
+                fmt=pdf_image_format,
+                dpi=pdf_dpi,
+            )
+            result.cleanpaths = [i.filename for i in images]
+            results.append(result)
+            logger.info(
+                "* PDF converted {}:\n    - {}".format(
+                    filepath,
+                    "\n    - ".join(result.cleanpaths),
+                )
+            )
+        else:
+            try:
+                image = PIL.Image.open(filepath)
+            except PIL.UnidentifiedImageError:
+                logger.warning(f"* Ignoring incompatible file: {filepath}")
+                continue
+
+            # Correct orientation from EXIF data:
+            for orientation in ExifTags.TAGS.keys():
+                if ExifTags.TAGS[orientation] == "Orientation":
+                    break
+            exif = dict((image._getexif() or {}).items())
+            img_orientation = exif.get(orientation)
+            logger.info("Image {} has orientation {}".format(filepath, img_orientation))
+            if img_orientation == 3:
+                image = image.rotate(180, expand=True)
+                rotated = True
+            elif img_orientation == 6:
+                image = image.rotate(270, expand=True)
+                rotated = True
+            elif img_orientation == 8:
+                image = image.rotate(90, expand=True)
+                rotated = True
+            else:
+                rotated = False
+
+            if ext_lower not in textract_compatible_formats:
+                outpath = os.path.join(outfolder, f"{basename}.{preferred_image_format}")
+                image.save(outpath)
+                logger.info(f"* Converted image {filepath} to {outpath}")
+            elif rotated:
+                outpath = os.path.join(outfolder, filename)
+                image.save(outpath)
+                logger.info(f"* Rotated image {filepath} to {outpath}")
+            else:
+                outpath = os.path.join(outfolder, filename)
+
+                shutil.copy2(filepath, outpath)
+                logger.info(f"* Copied file {filepath} to {outpath}")
+            result.cleanpaths = [outpath]
+            results.append(result)
+
+    logger.info("Done!")
+    return results
+
+
+def parse_args():
+    """Parse SageMaker Processing Job CLI arguments to job parameters
+    """
+    parser = argparse.ArgumentParser(
+        description="Split and standardize documents into images for OCR"
+    )
+    parser.add_argument("--input", type=str, default="/opt/ml/processing/input/raw",
+        help="Folder where raw input images/documents are stored"
+    )
+    parser.add_argument("--output", type=str, default="/opt/ml/processing/output/imgs-clean",
+        help="Folder where cleaned output images should be saved"
+    )
+    parser.add_argument("--n-workers", type=int, default=cpu_count(),
+        help="Number of worker processes to use for extraction (default #CPU cores)"
+    )
+    args = parser.parse_args()
+    return args
+
+
+def process_shard(inputs: dict):
+    return clean_dataset_for_img_ocr(**inputs)
+
+
+if __name__ == "__main__":
+    # Main processing job script:
+    args = parse_args()
+
+    logger.info(f"Reading raw files from {args.input}")
+    rel_filepaths_all = sorted(filter(
+        lambda f: not (f.startswith(".") or "/." in f), # (Exclude hidden dot-files)
+        [
+            os.path.join(currpath, name)[len(args.input) + 1:]  # +1 for trailing '/'
+            for currpath, dirs, files in os.walk(args.input)
+            for name in files
+        ]
+    ))
+    logger.info(rel_filepaths_all[:10])
+    
+    logger.info(f"Processing {len(rel_filepaths_all)} files across {args.n_workers} processes")
+    with Pool(args.n_workers) as pool:
+        # TODO: Test pooling individual samples rather than list slices
+        # This would likely increase inter-process-communication overheads, but reduce risk of one
+        # process taking much longer to complete than others.
+        pool.map(
+            process_shard,
+            [
+                {
+                    "from_path": args.input,
+                    "to_path": args.output,
+                    "filepaths": rel_filepaths_all[ix::args.n_workers],
+                }
+                for ix in range(args.n_workers)
+            ],
+        )
+    logger.info("All done!")

--- a/notebooks/preproc/imgclean.py
+++ b/notebooks/preproc/imgclean.py
@@ -92,7 +92,7 @@ def clean_dataset_for_img_ocr(
         # Because we use all available cores, things can become unhappy if we don't provide a
         # little breathing space for any background procesess:
         time.sleep(0.5)
-        
+
         filename = os.path.basename(filepath)
         subfolder = os.path.dirname(filepath)[len(from_path) :]  # Includes leading slash!
         outfolder = to_path + subfolder
@@ -176,19 +176,27 @@ def clean_dataset_for_img_ocr(
 
 
 def parse_args():
-    """Parse SageMaker Processing Job CLI arguments to job parameters
-    """
+    """Parse SageMaker Processing Job CLI arguments to job parameters"""
     parser = argparse.ArgumentParser(
         description="Split and standardize documents into images for OCR"
     )
-    parser.add_argument("--input", type=str, default="/opt/ml/processing/input/raw",
-        help="Folder where raw input images/documents are stored"
+    parser.add_argument(
+        "--input",
+        type=str,
+        default="/opt/ml/processing/input/raw",
+        help="Folder where raw input images/documents are stored",
     )
-    parser.add_argument("--output", type=str, default="/opt/ml/processing/output/imgs-clean",
-        help="Folder where cleaned output images should be saved"
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="/opt/ml/processing/output/imgs-clean",
+        help="Folder where cleaned output images should be saved",
     )
-    parser.add_argument("--n-workers", type=int, default=cpu_count(),
-        help="Number of worker processes to use for extraction (default #CPU cores)"
+    parser.add_argument(
+        "--n-workers",
+        type=int,
+        default=cpu_count(),
+        help="Number of worker processes to use for extraction (default #CPU cores)",
     )
     args = parser.parse_args()
     return args
@@ -203,16 +211,18 @@ if __name__ == "__main__":
     args = parse_args()
 
     logger.info(f"Reading raw files from {args.input}")
-    rel_filepaths_all = sorted(filter(
-        lambda f: not (f.startswith(".") or "/." in f), # (Exclude hidden dot-files)
-        [
-            os.path.join(currpath, name)[len(args.input) + 1:]  # +1 for trailing '/'
-            for currpath, dirs, files in os.walk(args.input)
-            for name in files
-        ]
-    ))
+    rel_filepaths_all = sorted(
+        filter(
+            lambda f: not (f.startswith(".") or "/." in f),  # (Exclude hidden dot-files)
+            [
+                os.path.join(currpath, name)[len(args.input) + 1 :]  # +1 for trailing '/'
+                for currpath, dirs, files in os.walk(args.input)
+                for name in files
+            ],
+        )
+    )
     logger.info(rel_filepaths_all[:10])
-    
+
     logger.info(f"Processing {len(rel_filepaths_all)} files across {args.n_workers} processes")
     with Pool(args.n_workers) as pool:
         # TODO: Test pooling individual samples rather than list slices
@@ -224,7 +234,7 @@ if __name__ == "__main__":
                 {
                     "from_path": args.input,
                     "to_path": args.output,
-                    "filepaths": rel_filepaths_all[ix::args.n_workers],
+                    "filepaths": rel_filepaths_all[ix :: args.n_workers],
                 }
                 for ix in range(args.n_workers)
             ],

--- a/notebooks/preproc/imgclean.py
+++ b/notebooks/preproc/imgclean.py
@@ -34,6 +34,9 @@ def get_exif_tag_id_by_name(name: str) -> Optional[str]:
         return None
 
 
+ORIENTATION_EXIF_ID = get_exif_tag_id_by_name("Orientation")
+
+
 def split_filename(filename):
     basename, _, ext = filename.rpartition(".")
     return basename, ext
@@ -48,6 +51,151 @@ class ImageExtractionResult:
         self.cats = cats
 
 
+def clean_document_for_img_ocr(
+    rel_filepath: str,
+    from_basepath: str,
+    to_basepath: str,
+    pdf_dpi: int = 300,
+    pdf_image_format: str = "png",
+    allowed_formats: Iterable[str] = ("jpg", "jpeg", "png"),
+    preferred_image_format: str = "png",
+    wait: float = 0,
+) -> ImageExtractionResult:
+    """Process an individual PDF or image for use with SageMaker Ground Truth image task UIs
+
+    Extracts page images from PDFs, converts EXIF-rotated images to data-rotated.
+
+    Parameters
+    ----------
+    rel_filepath : str
+        Path (relative to from_basepath) to the raw document/image to be processed
+    from_basepath : str
+        Base input path which should be masked for mapping to `to_basepath`
+    to_basepath : str
+        Target path for converted files (subfolder structure will be preserved from input)
+    pdf_dpi : int
+        DPI resolution to extract images from PDFs (Default 300).
+    pdf_image_format : str
+        Format to extract images from PDFs (Default 'png').
+    allowed_formats : Iterable[str]
+        The set of permitted file formats for compatibility: Used to determine whether to convert
+        source images in other formats which PIL may still have been able to successfully load.
+        NOTE: Amazon Textract also supports 'tiff', but we left it out of the default list because
+        TIFF images seemed to break the SageMaker Ground Truth built-in bounding box UI as of some
+        tests in 2021-10. Default ('jpg', 'jpeg', 'png').
+    preferred_image_format : str
+        Format to be used when an image has been saved/converted (Default 'png').
+    wait : float
+        If !=0, this function will `time.sleep(wait)` before running. This is useful for batch jobs
+        utilizing all available cores on a machine, where errors might arise if we don't provide a
+        little room for any background processes.
+    """
+    if wait:
+        time.sleep(wait)
+
+    full_filepath = os.path.join(from_basepath, rel_filepath)
+    filename = os.path.basename(rel_filepath)
+    subfolder = os.path.dirname(rel_filepath)
+    outfolder = os.path.join(to_basepath, subfolder)
+    os.makedirs(outfolder, exist_ok=True)
+    basename, ext = split_filename(filename)
+    ext_lower = ext.lower()
+    result = ImageExtractionResult(
+        rawpath=full_filepath,
+        cleanpaths=[],
+        cats=subfolder[1:].split(os.path.sep),  # Strip leading slash to avoid initial ''
+    )
+    if ext_lower == "pdf":
+        logger.info(
+            "Converting {} to {}/{}*.{}".format(
+                full_filepath,
+                outfolder,
+                basename + "-",
+                pdf_image_format,
+            )
+        )
+        images = pdf2image.convert_from_path(
+            full_filepath,
+            output_folder=outfolder,
+            output_file=basename + "-",
+            # TODO: Use paths_only option to return paths instead of image objs
+            fmt=pdf_image_format,
+            dpi=pdf_dpi,
+        )
+        result.cleanpaths = [i.filename for i in images]
+        logger.info(
+            "* PDF converted {}:\n    - {}".format(
+                full_filepath,
+                "\n    - ".join(result.cleanpaths),
+            )
+        )
+        return result
+
+    try:
+        image = PIL.Image.open(full_filepath)
+    except PIL.UnidentifiedImageError:
+        logger.warning(f"* Ignoring incompatible file: {full_filepath}")
+        return None
+
+    # Some "image" formats (notably TIFF) support multiple pages as "frames":
+    n_image_pages = getattr(image, "n_frames", 1)
+    if n_image_pages > 1:
+        logger.info("Extracting %s pages from file %s", n_image_pages, full_filepath)
+    convert_format = not ext_lower in allowed_formats
+    outpaths = []
+    for ixpage in range(n_image_pages):
+        if n_image_pages > 1:
+            image.seek(ixpage)
+
+        # Correct orientation from EXIF data:
+        exif = dict((image.getexif() or {}).items())
+        img_orientation = exif.get(ORIENTATION_EXIF_ID)
+        if img_orientation == 3:
+            image = image.rotate(180, expand=True)
+            rotated = True
+        elif img_orientation == 6:
+            image = image.rotate(270, expand=True)
+            rotated = True
+        elif img_orientation == 8:
+            image = image.rotate(90, expand=True)
+            rotated = True
+        else:
+            rotated = False
+
+        if n_image_pages == 1 and not (convert_format or rotated):
+            # Special case where image file can just be copied across:
+            outpath = os.path.join(outfolder, filename)
+            shutil.copy2(full_filepath, outpath)
+        else:
+            outpath = os.path.join(
+                outfolder,
+                "".join(
+                    (
+                        basename,
+                        "-%04i" % (ixpage + 1) if n_image_pages > 1 else "",
+                        ".",
+                        preferred_image_format if convert_format else ext,
+                    )
+                ),
+            )
+            image.save(outpath)
+
+        outpaths.append(outpath)
+        logger.info(
+            "* %s image %s%s (orientation %s) to %s",
+            "Converted"
+            if convert_format
+            else ("Rotated" if rotated else ("Extracted" if n_image_pages > 1 else "Copied")),
+            full_filepath,
+            f" page {ixpage + 1}" if n_image_pages > 1 else "",
+            img_orientation,
+            outpath,
+        )
+
+    result.cleanpaths = outpaths
+    return result
+
+
 def clean_dataset_for_img_ocr(
     from_path: str,
     to_path: str,
@@ -59,7 +207,9 @@ def clean_dataset_for_img_ocr(
 ) -> List[ImageExtractionResult]:
     """Process a mixed PDF/image dataset for use with SageMaker Ground Truth image task UIs
 
-    Extracts page images from PDFs, converts EXIF-rotated images to data-rotated.
+    This is a convenience method for processing documents directly in notebook, and is not used
+    when run as a processing job. Extracts page images from PDFs, converts EXIF-rotated images to
+    data-rotated.
 
     Parameters
     ----------
@@ -84,128 +234,32 @@ def clean_dataset_for_img_ocr(
         Format to be used when an image has been saved/converted (Default 'png').
     """
     results = []
-    if filepaths:
-        # Users will supply relative filepaths, but our code below expects to include from_path:
-        filepaths = [os.path.join(from_path, p) for p in filepaths]
-    else:
+    if not filepaths:
         # List input files automatically by walking the from_path dir:
-        filepaths = list(
-            filter(
+        filepaths = [
+            path[len(from_path) + 1 :]  # Convert to relative path (+1 for trailing '/')
+            for path in filter(
                 lambda path: "/." not in path,  # Ignore hidden stuff e.g. .ipynb_checkpoints
                 (os.path.join(path, f) for path, _, files in os.walk(from_path) for f in files),
             )
-        )
-    ORIENTATION_EXIF_ID = get_exif_tag_id_by_name("Orientation")
+        ]
     os.makedirs(to_path, exist_ok=True)
 
     for ixfilepath, filepath in enumerate(filepaths):
-        # TODO: Would be better to have global progress logging than per-worker
-        logger.debug("Doc %s of %s", ixfilepath + 1, len(filepaths))
-        # Because we use all available cores, things can become unhappy if we don't provide a
-        # little breathing space for any background procesess:
-        time.sleep(0.5)
-
-        filename = os.path.basename(filepath)
-        subfolder = os.path.dirname(filepath)[len(from_path) :]  # Includes leading slash!
-        outfolder = to_path + subfolder
-        os.makedirs(outfolder, exist_ok=True)
-        basename, ext = split_filename(filename)
-        ext_lower = ext.lower()
-        result = ImageExtractionResult(
-            rawpath=filepath,
-            cleanpaths=[],
-            cats=subfolder[1:].split(os.path.sep),  # Strip leading slash to avoid initial ''
+        logger.info("Doc %s of %s", ixfilepath + 1, len(filepaths))
+        result = clean_document_for_img_ocr(
+            filepath,
+            from_path,
+            to_path,
+            pdf_dpi=pdf_dpi,
+            pdf_image_format=pdf_image_format,
+            allowed_formats=allowed_formats,
+            preferred_image_format=preferred_image_format,
+            wait=0,  # No need to pause in single-threaded for loop
         )
-        if ext_lower == "pdf":
-            logger.info(
-                "Converting {} to {}/{}*.{}".format(
-                    filepath,
-                    outfolder,
-                    basename + "-",
-                    pdf_image_format,
-                )
-            )
-            images = pdf2image.convert_from_path(
-                filepath,
-                output_folder=outfolder,
-                output_file=basename + "-",
-                # TODO: Use paths_only option to return paths instead of image objs
-                fmt=pdf_image_format,
-                dpi=pdf_dpi,
-            )
-            result.cleanpaths = [i.filename for i in images]
+        if result:
             results.append(result)
-            logger.info(
-                "* PDF converted {}:\n    - {}".format(
-                    filepath,
-                    "\n    - ".join(result.cleanpaths),
-                )
-            )
-            continue  # PDF processed successfully
-
-        try:
-            image = PIL.Image.open(filepath)
-        except PIL.UnidentifiedImageError:
-            logger.warning(f"* Ignoring incompatible file: {filepath}")
-            continue  # Skip file
-
-        # Some "image" formats (notably TIFF) support multiple pages as "frames":
-        n_image_pages = getattr(image, "n_frames", 1)
-        if n_image_pages > 1:
-            logger.info("Extracting %s pages from file %s", n_image_pages, filepath)
-        convert_format = not ext_lower in allowed_formats
-        outpaths = []
-        for ixpage in range(n_image_pages):
-            if n_image_pages > 1:
-                image.seek(ixpage)
-
-            # Correct orientation from EXIF data:
-            exif = dict((image.getexif() or {}).items())
-            img_orientation = exif.get(ORIENTATION_EXIF_ID)
-            if img_orientation == 3:
-                image = image.rotate(180, expand=True)
-                rotated = True
-            elif img_orientation == 6:
-                image = image.rotate(270, expand=True)
-                rotated = True
-            elif img_orientation == 8:
-                image = image.rotate(90, expand=True)
-                rotated = True
-            else:
-                rotated = False
-
-            if n_image_pages == 1 and not (convert_format or rotated):
-                # Special case where image file can just be copied across:
-                outpath = os.path.join(outfolder, filename)
-                shutil.copy2(filepath, outpath)
-            else:
-                outpath = os.path.join(
-                    outfolder,
-                    "".join(
-                        (
-                            basename,
-                            "-%04i" % (ixpage + 1) if n_image_pages > 1 else "",
-                            ".",
-                            preferred_image_format if convert_format else ext,
-                        )
-                    ),
-                )
-                image.save(outpath)
-
-            outpaths.append(outpath)
-            logger.info(
-                "* %s image %s%s (orientation %s) to %s",
-                "Converted"
-                if convert_format
-                else ("Rotated" if rotated else ("Extracted" if n_image_pages > 1 else "Copied")),
-                filepath,
-                f" page {ixpage + 1}" if n_image_pages > 1 else "",
-                img_orientation,
-                outpath,
-            )
-
-        result.cleanpaths = outpaths
-        results.append(result)
+        # Otherwise doc was skipped and warning already printed
 
     logger.info("Done!")
     return results
@@ -238,15 +292,20 @@ def parse_args():
     return args
 
 
-def process_shard(inputs: dict):
-    return clean_dataset_for_img_ocr(**inputs)
+def process_doc_in_worker(inputs: dict):
+    return clean_document_for_img_ocr(
+        rel_filepath=inputs["rel_filepath"],
+        from_basepath=inputs["in_folder"],
+        to_basepath=inputs["out_folder"],
+        wait=0.5,
+    )
 
 
 if __name__ == "__main__":
     # Main processing job script:
     args = parse_args()
 
-    logger.info(f"Reading raw files from {args.input}")
+    logger.info("Reading raw files from %s", args.input)
     rel_filepaths_all = sorted(
         filter(
             lambda f: not (f.startswith(".") or "/." in f),  # (Exclude hidden dot-files)
@@ -257,22 +316,22 @@ if __name__ == "__main__":
             ],
         )
     )
-    logger.info(rel_filepaths_all[:10])
 
-    logger.info(f"Processing {len(rel_filepaths_all)} files across {args.n_workers} processes")
+    n_docs = len(rel_filepaths_all)
+    logger.info("Processing %s files across %s processes", n_docs, args.n_workers)
     with Pool(args.n_workers) as pool:
-        # TODO: Test pooling individual samples rather than list slices
-        # This would likely increase inter-process-communication overheads, but reduce risk of one
-        # process taking much longer to complete than others.
-        pool.map(
-            process_shard,
-            [
-                {
-                    "from_path": args.input,
-                    "to_path": args.output,
-                    "filepaths": rel_filepaths_all[ix :: args.n_workers],
-                }
-                for ix in range(args.n_workers)
-            ],
-        )
+        for ix, result in enumerate(
+            pool.imap_unordered(
+                process_doc_in_worker,
+                [
+                    {
+                        "in_folder": args.input,
+                        "out_folder": args.output,
+                        "rel_filepath": path,
+                    }
+                    for path in rel_filepaths_all
+                ],
+            )
+        ):
+            logger.info("Processed doc %s of %s", ix + 1, n_docs)
     logger.info("All done!")

--- a/notebooks/preproc/imgclean.py
+++ b/notebooks/preproc/imgclean.py
@@ -5,13 +5,11 @@
 
 # Python Built-Ins:
 import argparse
-import json
 import logging
 from multiprocessing import cpu_count, Pool
 import os
 import shutil
 import time
-from types import SimpleNamespace
 from typing import Iterable, List, Optional
 
 logging.basicConfig(level="INFO", format="%(asctime)s %(name)s [%(levelname)s] %(message)s")
@@ -23,6 +21,17 @@ from PIL import ExifTags
 
 
 logger = logging.getLogger("preproc")
+
+
+def get_exif_tag_id_by_name(name: str) -> Optional[str]:
+    """Find a numeric EXIF tag ID by common name
+
+    As per https://pillow.readthedocs.io/en/stable/reference/ExifTags.html
+    """
+    try:
+        return next(k for k in ExifTags.TAGS.keys() if ExifTags.TAGS[k] == name)
+    except StopIteration:
+        return None
 
 
 def split_filename(filename):
@@ -45,7 +54,7 @@ def clean_dataset_for_img_ocr(
     filepaths: Optional[Iterable[str]] = None,
     pdf_dpi: int = 300,
     pdf_image_format: str = "png",
-    textract_compatible_formats: Iterable[str] = ("jpg", "jpeg", "png"),
+    allowed_formats: Iterable[str] = ("jpg", "jpeg", "png"),
     preferred_image_format: str = "png",
 ) -> List[ImageExtractionResult]:
     """Process a mixed PDF/image dataset for use with SageMaker Ground Truth image task UIs
@@ -65,9 +74,12 @@ def clean_dataset_for_img_ocr(
         DPI resolution to extract images from PDFs (Default 300).
     pdf_image_format : str
         Format to extract images from PDFs (Default 'png').
-    textract_compatible_formats : Iterable[str]
-        The set of compatible file formats for Textract: Used to determine whether to convert
+    allowed_formats : Iterable[str]
+        The set of permitted file formats for compatibility: Used to determine whether to convert
         source images in other formats which PIL may still have been able to successfully load.
+        NOTE: Amazon Textract also supports 'tiff', but we left it out of the default list because
+        TIFF images seemed to break the SageMaker Ground Truth built-in bounding box UI as of some
+        tests in 2021-10. Default ('jpg', 'jpeg', 'png').
     preferred_image_format : str
         Format to be used when an image has been saved/converted (Default 'png').
     """
@@ -83,7 +95,7 @@ def clean_dataset_for_img_ocr(
                 (os.path.join(path, f) for path, _, files in os.walk(from_path) for f in files),
             )
         )
-    n_files_total = len(filepaths)
+    ORIENTATION_EXIF_ID = get_exif_tag_id_by_name("Orientation")
     os.makedirs(to_path, exist_ok=True)
 
     for ixfilepath, filepath in enumerate(filepaths):
@@ -129,20 +141,27 @@ def clean_dataset_for_img_ocr(
                     "\n    - ".join(result.cleanpaths),
                 )
             )
-        else:
-            try:
-                image = PIL.Image.open(filepath)
-            except PIL.UnidentifiedImageError:
-                logger.warning(f"* Ignoring incompatible file: {filepath}")
-                continue
+            continue  # PDF processed successfully
+
+        try:
+            image = PIL.Image.open(filepath)
+        except PIL.UnidentifiedImageError:
+            logger.warning(f"* Ignoring incompatible file: {filepath}")
+            continue  # Skip file
+
+        # Some "image" formats (notably TIFF) support multiple pages as "frames":
+        n_image_pages = getattr(image, "n_frames", 1)
+        if n_image_pages > 1:
+            logger.info("Extracting %s pages from file %s", n_image_pages, filepath)
+        convert_format = not ext_lower in allowed_formats
+        outpaths = []
+        for ixpage in range(n_image_pages):
+            if n_image_pages > 1:
+                image.seek(ixpage)
 
             # Correct orientation from EXIF data:
-            for orientation in ExifTags.TAGS.keys():
-                if ExifTags.TAGS[orientation] == "Orientation":
-                    break
-            exif = dict((image._getexif() or {}).items())
-            img_orientation = exif.get(orientation)
-            logger.info("Image {} has orientation {}".format(filepath, img_orientation))
+            exif = dict((image.getexif() or {}).items())
+            img_orientation = exif.get(ORIENTATION_EXIF_ID)
             if img_orientation == 3:
                 image = image.rotate(180, expand=True)
                 rotated = True
@@ -155,21 +174,38 @@ def clean_dataset_for_img_ocr(
             else:
                 rotated = False
 
-            if ext_lower not in textract_compatible_formats:
-                outpath = os.path.join(outfolder, f"{basename}.{preferred_image_format}")
-                image.save(outpath)
-                logger.info(f"* Converted image {filepath} to {outpath}")
-            elif rotated:
+            if n_image_pages == 1 and not (convert_format or rotated):
+                # Special case where image file can just be copied across:
                 outpath = os.path.join(outfolder, filename)
-                image.save(outpath)
-                logger.info(f"* Rotated image {filepath} to {outpath}")
-            else:
-                outpath = os.path.join(outfolder, filename)
-
                 shutil.copy2(filepath, outpath)
-                logger.info(f"* Copied file {filepath} to {outpath}")
-            result.cleanpaths = [outpath]
-            results.append(result)
+            else:
+                outpath = os.path.join(
+                    outfolder,
+                    "".join(
+                        (
+                            basename,
+                            "-%04i" % (ixpage + 1) if n_image_pages > 1 else "",
+                            ".",
+                            preferred_image_format if convert_format else ext,
+                        )
+                    ),
+                )
+                image.save(outpath)
+
+            outpaths.append(outpath)
+            logger.info(
+                "* %s image %s%s (orientation %s) to %s",
+                "Converted"
+                if convert_format
+                else ("Rotated" if rotated else ("Extracted" if n_image_pages > 1 else "Copied")),
+                filepath,
+                f" page {ixpage + 1}" if n_image_pages > 1 else "",
+                img_orientation,
+                outpath,
+            )
+
+        result.cleanpaths = outpaths
+        results.append(result)
 
     logger.info("Done!")
     return results

--- a/notebooks/util/preproc.py
+++ b/notebooks/util/preproc.py
@@ -57,9 +57,7 @@ def get_exif_tag_id_by_name(name: str) -> Optional[str]:
     As per https://pillow.readthedocs.io/en/stable/reference/ExifTags.html
     """
     try:
-        return next(
-            k for k in ExifTags.TAGS.keys() if ExifTags.TAGS[k] == name
-        )
+        return next(k for k in ExifTags.TAGS.keys() if ExifTags.TAGS[k] == name)
     except StopIteration:
         return None
 
@@ -168,7 +166,7 @@ def clean_dataset_for_img_ocr(
         except PIL.UnidentifiedImageError:
             logger.warning(f"* Ignoring incompatible file: {filepath}")
             continue  # Skip file
-            
+
         # Some "image" formats (notably TIFF) support multiple pages as "frames":
         n_image_pages = getattr(image, "n_frames", 1)
         if n_image_pages > 1:
@@ -201,23 +199,23 @@ def clean_dataset_for_img_ocr(
             else:
                 outpath = os.path.join(
                     outfolder,
-                    "".join((
-                        basename,
-                        "-%04i" % (ixpage + 1) if n_image_pages > 1 else "",
-                        ".",
-                        preferred_image_format if convert_format else ext,
-                    )),
+                    "".join(
+                        (
+                            basename,
+                            "-%04i" % (ixpage + 1) if n_image_pages > 1 else "",
+                            ".",
+                            preferred_image_format if convert_format else ext,
+                        )
+                    ),
                 )
                 image.save(outpath)
 
             outpaths.append(outpath)
             logger.info(
                 "* %s image %s%s (orientation %s) to %s",
-                "Converted" if convert_format else (
-                    "Rotated" if rotated else (
-                        "Extracted" if n_image_pages > 1 else "Copied"
-                    )
-                ),
+                "Converted"
+                if convert_format
+                else ("Rotated" if rotated else ("Extracted" if n_image_pages > 1 else "Copied")),
                 filepath,
                 f" page {ixpage + 1}" if n_image_pages > 1 else "",
                 img_orientation,
@@ -559,12 +557,14 @@ def build_data_manifest(
             # List the matching page images in S3:
             rel_filedir, _, filename = rel_filepath.rpartition("/")
             filename_root = filename.rpartition(".")[0]
-            file_img_s3key_prefix = "".join((
-                imgs_s3key_root,
-                "/",
-                rel_filedir + "/" if rel_filedir else "",
-                filename_root,
-            ))
+            file_img_s3key_prefix = "".join(
+                (
+                    imgs_s3key_root,
+                    "/",
+                    rel_filedir + "/" if rel_filedir else "",
+                    filename_root,
+                )
+            )
             img_candidate_s3keys = list(
                 map(
                     lambda o: o.key,

--- a/notebooks/util/preproc.py
+++ b/notebooks/util/preproc.py
@@ -92,6 +92,7 @@ def clean_dataset_for_img_ocr(
     preferred_image_format : str
         Format to be used when an image has been saved/converted (Default 'png').
     """
+    # TODO: DeleteMe and any other no-longer-required utils with new SMProcessing job
     results = []
     if filepaths:
         # Users will supply relative filepaths, but our code below expects to include from_path:

--- a/notebooks/util/project.py
+++ b/notebooks/util/project.py
@@ -47,6 +47,7 @@ class ProjectSession:
         "static/InputBucket": "pipeline_input_bucket_name",
         "static/ReviewsBucket": "pipeline_reviews_bucket_name",
         "static/PipelineStateMachine": "pipeline_sfn_arn",
+        "static/SMDockerBuildRole": "sm_image_build_role",
     }
     DYNAMIC_PARAM_NAMES: Dict[str, str] = {
         "config/HumanReviewFlowArn": "a2i_review_flow_arn_param",
@@ -60,6 +61,7 @@ class ProjectSession:
     pipeline_reviews_bucket_name: str
     pipeline_sfn_arn: str
     plain_textract_sfn_arn: str
+    sm_image_build_role: str
     # Configurable parameters (names in SSM):
     a2i_review_flow_arn_param: str
     entity_config_param: str

--- a/poetry.lock
+++ b/poetry.lock
@@ -14,1092 +14,1124 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "aws-cdk.assets"
-version = "1.122.0"
+version = "1.130.0"
 description = "This module is deprecated. All types are now available under the core module"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.cx-api" = "1.122.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-apigateway"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::ApiGateway"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-certificatemanager" = "1.122.0"
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-cognito" = "1.122.0"
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-elasticloadbalancingv2" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.aws-logs" = "1.122.0"
-"aws-cdk.aws-s3" = "1.122.0"
-"aws-cdk.aws-s3-assets" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.cx-api" = "1.122.0"
+"aws-cdk.aws-certificatemanager" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-cognito" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-elasticloadbalancingv2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.aws-s3-assets" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-applicationautoscaling"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::ApplicationAutoScaling"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-autoscaling-common" = "1.122.0"
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-autoscaling-common" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-autoscaling"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::AutoScaling"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-autoscaling-common" = "1.122.0"
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-elasticloadbalancing" = "1.122.0"
-"aws-cdk.aws-elasticloadbalancingv2" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-sns" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-autoscaling-common" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-elasticloadbalancing" = "1.130.0"
+"aws-cdk.aws-elasticloadbalancingv2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-sns" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-autoscaling-common"
-version = "1.122.0"
+version = "1.130.0"
 description = "Common implementation package for @aws-cdk/aws-autoscaling and @aws-cdk/aws-applicationautoscaling"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-autoscaling-hooktargets"
-version = "1.122.0"
+version = "1.130.0"
 description = "Lifecycle hook for AWS AutoScaling"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-autoscaling" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.aws-sns" = "1.122.0"
-"aws-cdk.aws-sns-subscriptions" = "1.122.0"
-"aws-cdk.aws-sqs" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-autoscaling" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-sns" = "1.130.0"
+"aws-cdk.aws-sns-subscriptions" = "1.130.0"
+"aws-cdk.aws-sqs" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-certificatemanager"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::CertificateManager"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.aws-route53" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-route53" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-cloudformation"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::CloudFormation"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.aws-s3" = "1.122.0"
-"aws-cdk.aws-sns" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.cx-api" = "1.122.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.aws-sns" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-cloudfront"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::CloudFront"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-certificatemanager" = "1.122.0"
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.aws-s3" = "1.122.0"
-"aws-cdk.aws-ssm" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.cx-api" = "1.122.0"
+"aws-cdk.aws-certificatemanager" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.aws-ssm" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-cloudwatch"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::CloudWatch"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-codebuild"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::CodeBuild"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.assets" = "1.122.0"
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-codecommit" = "1.122.0"
-"aws-cdk.aws-codestarnotifications" = "1.122.0"
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-ecr" = "1.122.0"
-"aws-cdk.aws-ecr-assets" = "1.122.0"
-"aws-cdk.aws-events" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-logs" = "1.122.0"
-"aws-cdk.aws-s3" = "1.122.0"
-"aws-cdk.aws-s3-assets" = "1.122.0"
-"aws-cdk.aws-secretsmanager" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.region-info" = "1.122.0"
+"aws-cdk.assets" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-codecommit" = "1.130.0"
+"aws-cdk.aws-codestarnotifications" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-ecr" = "1.130.0"
+"aws-cdk.aws-ecr-assets" = "1.130.0"
+"aws-cdk.aws-events" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.aws-s3-assets" = "1.130.0"
+"aws-cdk.aws-secretsmanager" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.region-info" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-codecommit"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::CodeCommit"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-codestarnotifications" = "1.122.0"
-"aws-cdk.aws-events" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-codestarnotifications" = "1.130.0"
+"aws-cdk.aws-events" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-codeguruprofiler"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::CodeGuruProfiler"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-codepipeline"
-version = "1.122.0"
+version = "1.130.0"
 description = "Better interface to AWS Code Pipeline"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-codestarnotifications" = "1.122.0"
-"aws-cdk.aws-events" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-s3" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-codestarnotifications" = "1.130.0"
+"aws-cdk.aws-events" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-codestarnotifications"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::CodeStarNotifications"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-cognito"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::Cognito"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-certificatemanager" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.custom-resources" = "1.122.0"
+"aws-cdk.aws-certificatemanager" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.custom-resources" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-dynamodb"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::DynamoDB"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-applicationautoscaling" = "1.122.0"
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kinesis" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.custom-resources" = "1.122.0"
+"aws-cdk.aws-applicationautoscaling" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kinesis" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.custom-resources" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ec2"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::EC2"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-logs" = "1.122.0"
-"aws-cdk.aws-s3" = "1.122.0"
-"aws-cdk.aws-s3-assets" = "1.122.0"
-"aws-cdk.aws-ssm" = "1.122.0"
-"aws-cdk.cloud-assembly-schema" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.cx-api" = "1.122.0"
-"aws-cdk.region-info" = "1.122.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.aws-s3-assets" = "1.130.0"
+"aws-cdk.aws-ssm" = "1.130.0"
+"aws-cdk.cloud-assembly-schema" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
+"aws-cdk.region-info" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ecr"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::ECR"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-events" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-events" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ecr-assets"
-version = "1.122.0"
+version = "1.130.0"
 description = "Docker image assets deployed to ECR"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.assets" = "1.122.0"
-"aws-cdk.aws-ecr" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-s3" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.cx-api" = "1.122.0"
+"aws-cdk.assets" = "1.130.0"
+"aws-cdk.aws-ecr" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ecs"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::ECS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-applicationautoscaling" = "1.122.0"
-"aws-cdk.aws-autoscaling" = "1.122.0"
-"aws-cdk.aws-autoscaling-hooktargets" = "1.122.0"
-"aws-cdk.aws-certificatemanager" = "1.122.0"
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-ecr" = "1.122.0"
-"aws-cdk.aws-ecr-assets" = "1.122.0"
-"aws-cdk.aws-elasticloadbalancing" = "1.122.0"
-"aws-cdk.aws-elasticloadbalancingv2" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.aws-logs" = "1.122.0"
-"aws-cdk.aws-route53" = "1.122.0"
-"aws-cdk.aws-route53-targets" = "1.122.0"
-"aws-cdk.aws-s3" = "1.122.0"
-"aws-cdk.aws-s3-assets" = "1.122.0"
-"aws-cdk.aws-secretsmanager" = "1.122.0"
-"aws-cdk.aws-servicediscovery" = "1.122.0"
-"aws-cdk.aws-sns" = "1.122.0"
-"aws-cdk.aws-sqs" = "1.122.0"
-"aws-cdk.aws-ssm" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.cx-api" = "1.122.0"
+"aws-cdk.aws-applicationautoscaling" = "1.130.0"
+"aws-cdk.aws-autoscaling" = "1.130.0"
+"aws-cdk.aws-autoscaling-hooktargets" = "1.130.0"
+"aws-cdk.aws-certificatemanager" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-ecr" = "1.130.0"
+"aws-cdk.aws-ecr-assets" = "1.130.0"
+"aws-cdk.aws-elasticloadbalancing" = "1.130.0"
+"aws-cdk.aws-elasticloadbalancingv2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.aws-route53" = "1.130.0"
+"aws-cdk.aws-route53-targets" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.aws-s3-assets" = "1.130.0"
+"aws-cdk.aws-secretsmanager" = "1.130.0"
+"aws-cdk.aws-servicediscovery" = "1.130.0"
+"aws-cdk.aws-sns" = "1.130.0"
+"aws-cdk.aws-sqs" = "1.130.0"
+"aws-cdk.aws-ssm" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-efs"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::EFS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.cloud-assembly-schema" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.cx-api" = "1.122.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.cloud-assembly-schema" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-eks"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::EKS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-autoscaling" = "1.122.0"
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.aws-ssm" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.custom-resources" = "1.122.0"
-"aws-cdk.lambda-layer-awscli" = "1.122.0"
-"aws-cdk.lambda-layer-kubectl" = "1.122.0"
+"aws-cdk.aws-autoscaling" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-lambda-nodejs" = "1.130.0"
+"aws-cdk.aws-ssm" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.custom-resources" = "1.130.0"
+"aws-cdk.lambda-layer-awscli" = "1.130.0"
+"aws-cdk.lambda-layer-kubectl" = "1.130.0"
+"aws-cdk.lambda-layer-node-proxy-agent" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-elasticloadbalancing"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::ElasticLoadBalancing"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-elasticloadbalancingv2"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::ElasticLoadBalancingV2"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-certificatemanager" = "1.122.0"
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.aws-s3" = "1.122.0"
-"aws-cdk.cloud-assembly-schema" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.cx-api" = "1.122.0"
-"aws-cdk.region-info" = "1.122.0"
+"aws-cdk.aws-certificatemanager" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.cloud-assembly-schema" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
+"aws-cdk.region-info" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-events"
-version = "1.122.0"
+version = "1.130.0"
 description = "Amazon EventBridge Construct Library"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-events-targets"
-version = "1.122.0"
+version = "1.130.0"
 description = "Event targets for Amazon EventBridge"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-apigateway" = "1.122.0"
-"aws-cdk.aws-codebuild" = "1.122.0"
-"aws-cdk.aws-codepipeline" = "1.122.0"
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-ecs" = "1.122.0"
-"aws-cdk.aws-events" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kinesis" = "1.122.0"
-"aws-cdk.aws-kinesisfirehose" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.aws-logs" = "1.122.0"
-"aws-cdk.aws-sns" = "1.122.0"
-"aws-cdk.aws-sns-subscriptions" = "1.122.0"
-"aws-cdk.aws-sqs" = "1.122.0"
-"aws-cdk.aws-stepfunctions" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.custom-resources" = "1.122.0"
+"aws-cdk.aws-apigateway" = "1.130.0"
+"aws-cdk.aws-codebuild" = "1.130.0"
+"aws-cdk.aws-codepipeline" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-ecs" = "1.130.0"
+"aws-cdk.aws-events" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kinesis" = "1.130.0"
+"aws-cdk.aws-kinesisfirehose" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.aws-sns" = "1.130.0"
+"aws-cdk.aws-sns-subscriptions" = "1.130.0"
+"aws-cdk.aws-sqs" = "1.130.0"
+"aws-cdk.aws-stepfunctions" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.custom-resources" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-globalaccelerator"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::GlobalAccelerator"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.custom-resources" = "1.122.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.custom-resources" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-iam"
-version = "1.122.0"
+version = "1.130.0"
 description = "CDK routines for easily assigning correct and minimal IAM permissions"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.region-info" = "1.122.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.region-info" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-kinesis"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::Kinesis"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-logs" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-kinesisfirehose"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::KinesisFirehose"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kinesis" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.aws-logs" = "1.122.0"
-"aws-cdk.aws-s3" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.region-info" = "1.122.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kinesis" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.region-info" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-kms"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::KMS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.cloud-assembly-schema" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.cx-api" = "1.122.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.cloud-assembly-schema" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-lambda"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::Lambda"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-applicationautoscaling" = "1.122.0"
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-codeguruprofiler" = "1.122.0"
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-ecr" = "1.122.0"
-"aws-cdk.aws-ecr-assets" = "1.122.0"
-"aws-cdk.aws-efs" = "1.122.0"
-"aws-cdk.aws-events" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-logs" = "1.122.0"
-"aws-cdk.aws-s3" = "1.122.0"
-"aws-cdk.aws-s3-assets" = "1.122.0"
-"aws-cdk.aws-signer" = "1.122.0"
-"aws-cdk.aws-sqs" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.cx-api" = "1.122.0"
-"aws-cdk.region-info" = "1.122.0"
+"aws-cdk.aws-applicationautoscaling" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-codeguruprofiler" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-ecr" = "1.130.0"
+"aws-cdk.aws-ecr-assets" = "1.130.0"
+"aws-cdk.aws-efs" = "1.130.0"
+"aws-cdk.aws-events" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.aws-s3-assets" = "1.130.0"
+"aws-cdk.aws-signer" = "1.130.0"
+"aws-cdk.aws-sqs" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
+"aws-cdk.region-info" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
+publication = ">=0.0.3"
+
+[[package]]
+name = "aws-cdk.aws-lambda-nodejs"
+version = "1.130.0"
+description = "The CDK Construct Library for AWS Lambda in Node.js"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+constructs = ">=3.3.69,<4.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-lambda-python"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS Lambda in Python"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-logs"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::Logs"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-s3-assets" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-s3-assets" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-route53"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::Route53"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-logs" = "1.122.0"
-"aws-cdk.cloud-assembly-schema" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.custom-resources" = "1.122.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.cloud-assembly-schema" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.custom-resources" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-route53-targets"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS Route53 Alias Targets"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-apigateway" = "1.122.0"
-"aws-cdk.aws-cloudfront" = "1.122.0"
-"aws-cdk.aws-cognito" = "1.122.0"
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-elasticloadbalancing" = "1.122.0"
-"aws-cdk.aws-elasticloadbalancingv2" = "1.122.0"
-"aws-cdk.aws-globalaccelerator" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-route53" = "1.122.0"
-"aws-cdk.aws-s3" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.region-info" = "1.122.0"
+"aws-cdk.aws-apigateway" = "1.130.0"
+"aws-cdk.aws-cloudfront" = "1.130.0"
+"aws-cdk.aws-cognito" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-elasticloadbalancing" = "1.130.0"
+"aws-cdk.aws-elasticloadbalancingv2" = "1.130.0"
+"aws-cdk.aws-globalaccelerator" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-route53" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.region-info" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-s3"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::S3"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-events" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.cx-api" = "1.122.0"
+"aws-cdk.aws-events" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-s3-assets"
-version = "1.122.0"
+version = "1.130.0"
 description = "Deploy local files and directories to S3"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.assets" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-s3" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.cx-api" = "1.122.0"
+"aws-cdk.assets" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-s3-notifications"
-version = "1.122.0"
+version = "1.130.0"
 description = "Bucket Notifications API for AWS S3"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.aws-s3" = "1.122.0"
-"aws-cdk.aws-sns" = "1.122.0"
-"aws-cdk.aws-sqs" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.aws-sns" = "1.130.0"
+"aws-cdk.aws-sqs" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-sam"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for the AWS Serverless Application Model (SAM) resources"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-secretsmanager"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::SecretsManager"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.aws-sam" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
-"aws-cdk.cx-api" = "1.122.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-sam" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-servicediscovery"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::ServiceDiscovery"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-elasticloadbalancingv2" = "1.122.0"
-"aws-cdk.aws-route53" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-elasticloadbalancingv2" = "1.130.0"
+"aws-cdk.aws-route53" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-signer"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::Signer"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-sns"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::SNS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-codestarnotifications" = "1.122.0"
-"aws-cdk.aws-events" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-sqs" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-codestarnotifications" = "1.130.0"
+"aws-cdk.aws-events" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-sqs" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-sns-subscriptions"
-version = "1.122.0"
+version = "1.130.0"
 description = "CDK Subscription Constructs for AWS SNS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.aws-sns" = "1.122.0"
-"aws-cdk.aws-sqs" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-sns" = "1.130.0"
+"aws-cdk.aws-sqs" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-sqs"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::SQS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ssm"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::SSM"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.cloud-assembly-schema" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.cloud-assembly-schema" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-stepfunctions"
-version = "1.122.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::StepFunctions"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-events" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-logs" = "1.122.0"
-"aws-cdk.aws-s3" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-events" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-stepfunctions-tasks"
-version = "1.122.0"
+version = "1.130.0"
 description = "Task integrations for AWS StepFunctions"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-apigateway" = "1.122.0"
-"aws-cdk.aws-cloudwatch" = "1.122.0"
-"aws-cdk.aws-codebuild" = "1.122.0"
-"aws-cdk.aws-dynamodb" = "1.122.0"
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-ecr" = "1.122.0"
-"aws-cdk.aws-ecr-assets" = "1.122.0"
-"aws-cdk.aws-ecs" = "1.122.0"
-"aws-cdk.aws-eks" = "1.122.0"
-"aws-cdk.aws-events" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-kms" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.aws-s3" = "1.122.0"
-"aws-cdk.aws-sns" = "1.122.0"
-"aws-cdk.aws-sqs" = "1.122.0"
-"aws-cdk.aws-stepfunctions" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-apigateway" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-codebuild" = "1.130.0"
+"aws-cdk.aws-dynamodb" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-ecr" = "1.130.0"
+"aws-cdk.aws-ecr-assets" = "1.130.0"
+"aws-cdk.aws-ecs" = "1.130.0"
+"aws-cdk.aws-eks" = "1.130.0"
+"aws-cdk.aws-events" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.aws-sns" = "1.130.0"
+"aws-cdk.aws-sqs" = "1.130.0"
+"aws-cdk.aws-stepfunctions" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.cloud-assembly-schema"
-version = "1.122.0"
+version = "1.130.0"
 description = "Cloud Assembly Schema"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.core"
-version = "1.122.0"
+version = "1.130.0"
 description = "AWS Cloud Development Kit Core Library"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.cloud-assembly-schema" = "1.122.0"
-"aws-cdk.cx-api" = "1.122.0"
-"aws-cdk.region-info" = "1.122.0"
+"aws-cdk.cloud-assembly-schema" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
+"aws-cdk.region-info" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.custom-resources"
-version = "1.122.0"
+version = "1.130.0"
 description = "Constructs for implementing CDK custom resources"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudformation" = "1.122.0"
-"aws-cdk.aws-ec2" = "1.122.0"
-"aws-cdk.aws-iam" = "1.122.0"
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.aws-logs" = "1.122.0"
-"aws-cdk.aws-sns" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-cloudformation" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.aws-sns" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.cx-api"
-version = "1.122.0"
+version = "1.130.0"
 description = "Cloud executable protocol"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.cloud-assembly-schema" = "1.122.0"
-jsii = ">=1.34.0,<2.0.0"
+"aws-cdk.cloud-assembly-schema" = "1.130.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.lambda-layer-awscli"
-version = "1.122.0"
+version = "1.130.0"
 description = "An AWS Lambda layer that contains the AWS CLI"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.lambda-layer-kubectl"
-version = "1.122.0"
+version = "1.130.0"
 description = "An AWS Lambda layer that contains the `kubectl` and `helm`"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-lambda" = "1.122.0"
-"aws-cdk.core" = "1.122.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
+publication = ">=0.0.3"
+
+[[package]]
+name = "aws-cdk.lambda-layer-node-proxy-agent"
+version = "1.130.0"
+description = "An AWS Lambda layer that contains the `proxy-agent` NPM dependency"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+constructs = ">=3.3.69,<4.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.region-info"
-version = "1.122.0"
+version = "1.130.0"
 description = "AWS region information, such as service principal names"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-jsii = ">=1.34.0,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
@@ -1300,7 +1332,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "jsii"
-version = "1.34.0"
+version = "1.41.0"
 description = "Python client for jsii runtime"
 category = "main"
 optional = false
@@ -1533,232 +1565,240 @@ attrs = [
     {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
 ]
 "aws-cdk.assets" = [
-    {file = "aws-cdk.assets-1.122.0.tar.gz", hash = "sha256:0c21c8746b994d82535ff71747674c7a64b2134c372b10c405efd2b5f909423c"},
-    {file = "aws_cdk.assets-1.122.0-py3-none-any.whl", hash = "sha256:d3d0d0d3f74f76e9c8e935b15034814b36f54d67d8889e343723f3a87d07743b"},
+    {file = "aws-cdk.assets-1.130.0.tar.gz", hash = "sha256:89628550ecfd4f2b3713cc515c5937ee766cc68cd39fc65dc15095a4fc92140f"},
+    {file = "aws_cdk.assets-1.130.0-py3-none-any.whl", hash = "sha256:88ee75118c7b34506acac8a3390e0f6360227f95764749ecf0cb8160532fef8d"},
 ]
 "aws-cdk.aws-apigateway" = [
-    {file = "aws-cdk.aws-apigateway-1.122.0.tar.gz", hash = "sha256:2a9527438b5cb65be50ed287772e215f8e45fe8a5cecb2660c74148b7d877cb0"},
-    {file = "aws_cdk.aws_apigateway-1.122.0-py3-none-any.whl", hash = "sha256:163d9f3a38e376de35c3308ff87c2cc1f96b37dbcb28552d46f8daa4304d4db4"},
+    {file = "aws-cdk.aws-apigateway-1.130.0.tar.gz", hash = "sha256:87909341ee6a99ac1dff9afccdd485732c19159e111d9b73474594179374a40c"},
+    {file = "aws_cdk.aws_apigateway-1.130.0-py3-none-any.whl", hash = "sha256:8c19d5dfd632b890b53a9a45b742c4b2280fbfba316a14ef66c43bc74f3a7299"},
 ]
 "aws-cdk.aws-applicationautoscaling" = [
-    {file = "aws-cdk.aws-applicationautoscaling-1.122.0.tar.gz", hash = "sha256:d907e1dffd8ff0c588fbffd467d17f882edaf879749c8d687e02c83988c63538"},
-    {file = "aws_cdk.aws_applicationautoscaling-1.122.0-py3-none-any.whl", hash = "sha256:e943ed2530dda6fd18ba58075bd0954e6074dc19c7a73a65d2bb76e4965388a2"},
+    {file = "aws-cdk.aws-applicationautoscaling-1.130.0.tar.gz", hash = "sha256:c60000e6a2b86392efcfb32066207cff19adbdbe0b68e1ee4281cf5b52255b29"},
+    {file = "aws_cdk.aws_applicationautoscaling-1.130.0-py3-none-any.whl", hash = "sha256:0bed99bbc03ae733450e03bd0c6b075fadc13ae0d9363fffa047e6de0d68be60"},
 ]
 "aws-cdk.aws-autoscaling" = [
-    {file = "aws-cdk.aws-autoscaling-1.122.0.tar.gz", hash = "sha256:dbde859b87e7ecdb2200ede0eaa8a9822cc4a66a7df77b74b896cd4235eaf39b"},
-    {file = "aws_cdk.aws_autoscaling-1.122.0-py3-none-any.whl", hash = "sha256:41299ab033e821348cb9edf143db76d540635144cef842794f9403a18814ff37"},
+    {file = "aws-cdk.aws-autoscaling-1.130.0.tar.gz", hash = "sha256:5e7c6e185021faf1a45c2022d6a74e98ffe12865fe810afd79433ecfcadd84de"},
+    {file = "aws_cdk.aws_autoscaling-1.130.0-py3-none-any.whl", hash = "sha256:169881d6bf6d5468f4024bf743f3397f157ac223d9119046478c9a2ee3ab40c6"},
 ]
 "aws-cdk.aws-autoscaling-common" = [
-    {file = "aws-cdk.aws-autoscaling-common-1.122.0.tar.gz", hash = "sha256:de23c8aa2780f1767b48f28873f63bd94dd3a193f072a2e73657d7432e7dc752"},
-    {file = "aws_cdk.aws_autoscaling_common-1.122.0-py3-none-any.whl", hash = "sha256:e641e6350d829eff953861062c768930d415758bd78651ceb1e2a0023bebf3c5"},
+    {file = "aws-cdk.aws-autoscaling-common-1.130.0.tar.gz", hash = "sha256:bdc5eee7f30163daf0a40b78e888d356da9815057153791daa6bc2b3d1288541"},
+    {file = "aws_cdk.aws_autoscaling_common-1.130.0-py3-none-any.whl", hash = "sha256:46bd7dffa2ff4bcb2c3ee86e4881d7994924f23f76b59fb346cbc48a7e5b90e4"},
 ]
 "aws-cdk.aws-autoscaling-hooktargets" = [
-    {file = "aws-cdk.aws-autoscaling-hooktargets-1.122.0.tar.gz", hash = "sha256:20f712e0e90ae1fb006e7bef46eb777bf367d637387534c42f87ed060bc1afc4"},
-    {file = "aws_cdk.aws_autoscaling_hooktargets-1.122.0-py3-none-any.whl", hash = "sha256:4dde1a1cf01bbe5dddd3c03ee9bb94d55a115aebcefab04b2aef0ea086591cd1"},
+    {file = "aws-cdk.aws-autoscaling-hooktargets-1.130.0.tar.gz", hash = "sha256:4a6e4211a68869cf243bf6a9d3ddb34584e04866b306d2792f0203660c272272"},
+    {file = "aws_cdk.aws_autoscaling_hooktargets-1.130.0-py3-none-any.whl", hash = "sha256:dd9ea94f3b35e2aa3ac6c822d2ecf21584b18f76ebfacdbfb13014a43e7b8462"},
 ]
 "aws-cdk.aws-certificatemanager" = [
-    {file = "aws-cdk.aws-certificatemanager-1.122.0.tar.gz", hash = "sha256:0c673543126ac4d3bdf2312f2e8906a88963dc86467fd584d9943518e2f8bd75"},
-    {file = "aws_cdk.aws_certificatemanager-1.122.0-py3-none-any.whl", hash = "sha256:a74a9c84ad9929b04cf9915df753025cc4d7b7e23d3cc1d33f494f9a23d8a180"},
+    {file = "aws-cdk.aws-certificatemanager-1.130.0.tar.gz", hash = "sha256:e95cb1c48e5b37afa10ff0bdac0c0793d276f0c00d26140c6707a1fb0db74dc8"},
+    {file = "aws_cdk.aws_certificatemanager-1.130.0-py3-none-any.whl", hash = "sha256:23ceb0486f5e17ed230a651401ce9807faf3efffe793b0e1cef7e224f6ed25c9"},
 ]
 "aws-cdk.aws-cloudformation" = [
-    {file = "aws-cdk.aws-cloudformation-1.122.0.tar.gz", hash = "sha256:d4ddc285b28c0627cfdeb072d2f5f0b661a260b9885f3866145e16dee98dfedb"},
-    {file = "aws_cdk.aws_cloudformation-1.122.0-py3-none-any.whl", hash = "sha256:0a28a8b6367d36747b80d9168c058e7d0939d6e7474b9fa06e0235a6cce5ebfa"},
+    {file = "aws-cdk.aws-cloudformation-1.130.0.tar.gz", hash = "sha256:c2176461dfd6bf46ad3143f9ca270e209e74d6a1f8d52e2260f4893b4b9ae228"},
+    {file = "aws_cdk.aws_cloudformation-1.130.0-py3-none-any.whl", hash = "sha256:0509fc5b6b6a6bae3752fe04a4b3f24776254e28bc5688238602b904852bd2ec"},
 ]
 "aws-cdk.aws-cloudfront" = [
-    {file = "aws-cdk.aws-cloudfront-1.122.0.tar.gz", hash = "sha256:57e2d3881475d3d0a745d3beded6ef74b64085634727467af1bd00aa3ebb6be0"},
-    {file = "aws_cdk.aws_cloudfront-1.122.0-py3-none-any.whl", hash = "sha256:9ef54407c09aa4346e46ef755ea488287558542242ceb5f82cdd55009f87ad26"},
+    {file = "aws-cdk.aws-cloudfront-1.130.0.tar.gz", hash = "sha256:b37c3dc074d148ead5b886736c4115d9325590674802a7b8aefc438273cafe2a"},
+    {file = "aws_cdk.aws_cloudfront-1.130.0-py3-none-any.whl", hash = "sha256:49fda23d1f2f6353204ce942775e49ce2e5155b83c1bdf85bc22ae05eae94836"},
 ]
 "aws-cdk.aws-cloudwatch" = [
-    {file = "aws-cdk.aws-cloudwatch-1.122.0.tar.gz", hash = "sha256:613cf3f60c602913b6bba2ef4f2fa3dbbbcb7a0778620b0a044ab85f45566fa4"},
-    {file = "aws_cdk.aws_cloudwatch-1.122.0-py3-none-any.whl", hash = "sha256:dfa8842d67c921b13300b45497a7329b74e853aaa48813d36c1c414176154673"},
+    {file = "aws-cdk.aws-cloudwatch-1.130.0.tar.gz", hash = "sha256:1034ca75148e8292d014927911ba45cb18fad459371988ed32afd4b9de999449"},
+    {file = "aws_cdk.aws_cloudwatch-1.130.0-py3-none-any.whl", hash = "sha256:10cbd1b7047267a6a1f566e7f1bfd1e85932a709bbca5419226d1b84b7e0a0ee"},
 ]
 "aws-cdk.aws-codebuild" = [
-    {file = "aws-cdk.aws-codebuild-1.122.0.tar.gz", hash = "sha256:66849e1ee8d1b1a5cd05320a4b8924866cb5647dff6c84f198c1dc9bb2e73202"},
-    {file = "aws_cdk.aws_codebuild-1.122.0-py3-none-any.whl", hash = "sha256:6245c1b63e0df9803931258ee8a770bb177b806978554a405c7ea14b99001569"},
+    {file = "aws-cdk.aws-codebuild-1.130.0.tar.gz", hash = "sha256:9954113e90395c1f45df9ac9b9f67211078d7e08dc0f5b6dbcffbde7c668bb73"},
+    {file = "aws_cdk.aws_codebuild-1.130.0-py3-none-any.whl", hash = "sha256:8f1641288742b18869a48cdc8e1f06026cfec4e1c79008ab812a9fb5d8532ea7"},
 ]
 "aws-cdk.aws-codecommit" = [
-    {file = "aws-cdk.aws-codecommit-1.122.0.tar.gz", hash = "sha256:e8cd18017f1e7a992bb452e4a3c6a704184d86423e269cc53bfc2488072972d6"},
-    {file = "aws_cdk.aws_codecommit-1.122.0-py3-none-any.whl", hash = "sha256:60a24be25f8056787215ada9fc81a603e10933db32ca20a54434fa433bb68ae9"},
+    {file = "aws-cdk.aws-codecommit-1.130.0.tar.gz", hash = "sha256:5008cbeab2b163a717bfca7b0078ae90a1678371d936333d15ab33acadc104a2"},
+    {file = "aws_cdk.aws_codecommit-1.130.0-py3-none-any.whl", hash = "sha256:6528aaca7faced1b8f0b8414264cefa3fad5a36c60b844b0ab0c2c390d08b659"},
 ]
 "aws-cdk.aws-codeguruprofiler" = [
-    {file = "aws-cdk.aws-codeguruprofiler-1.122.0.tar.gz", hash = "sha256:cb2db9299b666ec3b4da41aed7664e6ed399c7d04be9d6b10db34bbbaeb2c2f4"},
-    {file = "aws_cdk.aws_codeguruprofiler-1.122.0-py3-none-any.whl", hash = "sha256:4b8640fa0e4f199f5657144a8aa73bbdb6e73b9245e0fe73152f16b4846b2127"},
+    {file = "aws-cdk.aws-codeguruprofiler-1.130.0.tar.gz", hash = "sha256:b9d9473a3e052e3164759c3f1ee694b7fc9d604c92b4a3df36c31a1a92306917"},
+    {file = "aws_cdk.aws_codeguruprofiler-1.130.0-py3-none-any.whl", hash = "sha256:0462eb79554b407bed707eda3f840956ec81d442ddfad4a1e93da20c89152835"},
 ]
 "aws-cdk.aws-codepipeline" = [
-    {file = "aws-cdk.aws-codepipeline-1.122.0.tar.gz", hash = "sha256:6cc0a284be7bdc515c19dcb6be167bd71b01fc4dcc9b647e515523b92f42bcec"},
-    {file = "aws_cdk.aws_codepipeline-1.122.0-py3-none-any.whl", hash = "sha256:7d92ff4167c5e749ce85d73622d3058426ef065605e1537bd1a12f5c197a5105"},
+    {file = "aws-cdk.aws-codepipeline-1.130.0.tar.gz", hash = "sha256:d02ffd70cc499d010f84d4e5d61d7dca502c347d984c4343ce3217b0c2970341"},
+    {file = "aws_cdk.aws_codepipeline-1.130.0-py3-none-any.whl", hash = "sha256:06c3c6cb97b605eea24c0453ecde93fea4c12960b3b457eeb16be243f85c9023"},
 ]
 "aws-cdk.aws-codestarnotifications" = [
-    {file = "aws-cdk.aws-codestarnotifications-1.122.0.tar.gz", hash = "sha256:2f39fcc8e31ad81098c58578506425327c47b1a270a48a282bc118b5cb906372"},
-    {file = "aws_cdk.aws_codestarnotifications-1.122.0-py3-none-any.whl", hash = "sha256:84a92f8adf3d5834f287fcb7692830c4edc49a2839d10d50e004320e76d13c87"},
+    {file = "aws-cdk.aws-codestarnotifications-1.130.0.tar.gz", hash = "sha256:3c7f66d4c377e4f509b2719be4a2b1ac6efdbc4ab416eb56947a57ddd9290e27"},
+    {file = "aws_cdk.aws_codestarnotifications-1.130.0-py3-none-any.whl", hash = "sha256:89b8a5374616e732475f374acb1f8b26de20721e0d939dda733f7135754848e3"},
 ]
 "aws-cdk.aws-cognito" = [
-    {file = "aws-cdk.aws-cognito-1.122.0.tar.gz", hash = "sha256:ab53916a0b1ede41b83e7ff8707ea523964f7e8ea6c82201d06db05a55903d3f"},
-    {file = "aws_cdk.aws_cognito-1.122.0-py3-none-any.whl", hash = "sha256:fea02e69487e805f67aec35891758b79e65da171058b828eec4050bc45c9c9da"},
+    {file = "aws-cdk.aws-cognito-1.130.0.tar.gz", hash = "sha256:a5a88d52bc6ca6121ef75c3a965c85db916bf49f4aef9ec195edf412d79c4878"},
+    {file = "aws_cdk.aws_cognito-1.130.0-py3-none-any.whl", hash = "sha256:1de29da4f3a6928c8c1bc361ea622ec9bfbd3d575eace100eb22ff77a867942d"},
 ]
 "aws-cdk.aws-dynamodb" = [
-    {file = "aws-cdk.aws-dynamodb-1.122.0.tar.gz", hash = "sha256:a8fe6d23784ef414553e9a6db5dbd772f0ce48397033cfb502e87f5209cf6178"},
-    {file = "aws_cdk.aws_dynamodb-1.122.0-py3-none-any.whl", hash = "sha256:a1051a0cd5ad18fcd7efb842e9ccc40010c71e8cf2b58c556c3ea00153e36c92"},
+    {file = "aws-cdk.aws-dynamodb-1.130.0.tar.gz", hash = "sha256:1edf5786dbe9f4c8e2f07a0fddd2e1e90754b96eeea905e2e94582249c58f45d"},
+    {file = "aws_cdk.aws_dynamodb-1.130.0-py3-none-any.whl", hash = "sha256:48e8d55637eccc9d1689170e75c0967c75a16bb9eaf640c2de820fa4847cb8d0"},
 ]
 "aws-cdk.aws-ec2" = [
-    {file = "aws-cdk.aws-ec2-1.122.0.tar.gz", hash = "sha256:692da14aa55fec1f5012c3d69d8f6f0d970cc925560c0cac2a9638dac033afb9"},
-    {file = "aws_cdk.aws_ec2-1.122.0-py3-none-any.whl", hash = "sha256:004e0a011e9c533c7cde50de1a66ea15e192471135285f3fc0df01c92f32c4fb"},
+    {file = "aws-cdk.aws-ec2-1.130.0.tar.gz", hash = "sha256:e0220bc03d44ad4e7f04c8efacd65c52c32faeac3d62a752d114e5606c47a6c2"},
+    {file = "aws_cdk.aws_ec2-1.130.0-py3-none-any.whl", hash = "sha256:fde2b2252debcbdd309a74bf7f3c1b7aaa83a671511eb9f753105687e59cafc3"},
 ]
 "aws-cdk.aws-ecr" = [
-    {file = "aws-cdk.aws-ecr-1.122.0.tar.gz", hash = "sha256:2343188f979afeee3df2eb2f3e551ecdc44e2d984c41353cd02496548a31f42e"},
-    {file = "aws_cdk.aws_ecr-1.122.0-py3-none-any.whl", hash = "sha256:8c9c994fe47031d730ea6092a1bff6b9194573dac6bb311eb36e9f0de8b82f7d"},
+    {file = "aws-cdk.aws-ecr-1.130.0.tar.gz", hash = "sha256:0c3aad603cc3f8e7cf2901d9a1365fe5110ff46f7d739b89333691219b186b92"},
+    {file = "aws_cdk.aws_ecr-1.130.0-py3-none-any.whl", hash = "sha256:7a2f8720d2f23c3578979c53f486c66a8449e0fd8135c6e4f82d4bd653151ce9"},
 ]
 "aws-cdk.aws-ecr-assets" = [
-    {file = "aws-cdk.aws-ecr-assets-1.122.0.tar.gz", hash = "sha256:0141e4318ebec01a20dfe4a92997499bddba8761cd3577851855e484d090cdc0"},
-    {file = "aws_cdk.aws_ecr_assets-1.122.0-py3-none-any.whl", hash = "sha256:23113976268485c0d7595758bc2fa4921dd1d306f5a251a9068cde7215435782"},
+    {file = "aws-cdk.aws-ecr-assets-1.130.0.tar.gz", hash = "sha256:40ca779cde59bdc3fcd979385a2b87b8e5cb052e1a4ef76e43bd781458ea5ce3"},
+    {file = "aws_cdk.aws_ecr_assets-1.130.0-py3-none-any.whl", hash = "sha256:ddf5078a87529b4e5c2216bb71579fc0489b4dcdab6e7d5246dd1e1d10263e29"},
 ]
 "aws-cdk.aws-ecs" = [
-    {file = "aws-cdk.aws-ecs-1.122.0.tar.gz", hash = "sha256:14f3b8e9225ac8ed044d8f2e648f6ce4280b89621b12c229ff2df4cbcfedc5ab"},
-    {file = "aws_cdk.aws_ecs-1.122.0-py3-none-any.whl", hash = "sha256:68f0209287acb4f264d447c4a497867ed69c5d0c5e1abd3846122d974c0d9d2c"},
+    {file = "aws-cdk.aws-ecs-1.130.0.tar.gz", hash = "sha256:a3580068928eeeea07ab640b4982b8540fcd5204b0846d798df9def09f63f070"},
+    {file = "aws_cdk.aws_ecs-1.130.0-py3-none-any.whl", hash = "sha256:4fe8e7c0f218a0f81ee1b89179c2ec03d6c269d58b3af4b510b8bc9c2ee91250"},
 ]
 "aws-cdk.aws-efs" = [
-    {file = "aws-cdk.aws-efs-1.122.0.tar.gz", hash = "sha256:5c137ca46eef1bce9a38054117bfc7a7f35dba80a498706c16416319c60a7d42"},
-    {file = "aws_cdk.aws_efs-1.122.0-py3-none-any.whl", hash = "sha256:4e3f6b49a2f5817f7a8d77174b525640762fd3e962374210f430170e2323af9f"},
+    {file = "aws-cdk.aws-efs-1.130.0.tar.gz", hash = "sha256:8ed017fe4599bbfaa03dac74aa41cded39984813c8a6b14e280896aed0c8a39a"},
+    {file = "aws_cdk.aws_efs-1.130.0-py3-none-any.whl", hash = "sha256:ccf15abb0711725620d478f7b53e58f2f6109b77f6c47c5878dc00d70e196827"},
 ]
 "aws-cdk.aws-eks" = [
-    {file = "aws-cdk.aws-eks-1.122.0.tar.gz", hash = "sha256:eda72d464e413ba4d5679a51fca36290ec5384f3b29c1b39d84609aab57410e0"},
-    {file = "aws_cdk.aws_eks-1.122.0-py3-none-any.whl", hash = "sha256:c723bc1b78794b1024dbdfb2b1d98ff7213406c4ddd45b799dfa2a33cb37f627"},
+    {file = "aws-cdk.aws-eks-1.130.0.tar.gz", hash = "sha256:ed31e8e4e68c3bdd98abfdb351429e622e96734d69a0d2738f0bd17c90b673f9"},
+    {file = "aws_cdk.aws_eks-1.130.0-py3-none-any.whl", hash = "sha256:054afd912d9cd284d80aef6ea39f3c7a6107a9c57e2188e5179282e28650245e"},
 ]
 "aws-cdk.aws-elasticloadbalancing" = [
-    {file = "aws-cdk.aws-elasticloadbalancing-1.122.0.tar.gz", hash = "sha256:5b897e5775d2dfe68204f267fa1e860513ad25c1f972eca3d1aa9f6447f520ee"},
-    {file = "aws_cdk.aws_elasticloadbalancing-1.122.0-py3-none-any.whl", hash = "sha256:39639c57b2ecebf065a276be9392cd5de05be1d43dd33ea2335b918934f8a4a4"},
+    {file = "aws-cdk.aws-elasticloadbalancing-1.130.0.tar.gz", hash = "sha256:2236cc5dcc00e331faf1f3fcee7b85164865c4d2b8f8f0b7e072fafdf73cf001"},
+    {file = "aws_cdk.aws_elasticloadbalancing-1.130.0-py3-none-any.whl", hash = "sha256:aeaa65153c570818412214055a0806994a17021b2bec9a03bc302e649a6ffff1"},
 ]
 "aws-cdk.aws-elasticloadbalancingv2" = [
-    {file = "aws-cdk.aws-elasticloadbalancingv2-1.122.0.tar.gz", hash = "sha256:ed43ce2ea387ce9bd89d43fc940ad5a6ae244d2a99ec42eaf33e5f4b85448f79"},
-    {file = "aws_cdk.aws_elasticloadbalancingv2-1.122.0-py3-none-any.whl", hash = "sha256:467218a9a91f2f70818455db5e400322e17183a0d3a283dcc15915ef47f8b18b"},
+    {file = "aws-cdk.aws-elasticloadbalancingv2-1.130.0.tar.gz", hash = "sha256:73fb8e6dd1b13a00e2c7a2f06848231d20ed7d1fd3e9e59abe14f5d1b6d23e3d"},
+    {file = "aws_cdk.aws_elasticloadbalancingv2-1.130.0-py3-none-any.whl", hash = "sha256:0091afbc0a24f677c501b9ff2cc2e38a1b515623651946f19d840259a26ae5d2"},
 ]
 "aws-cdk.aws-events" = [
-    {file = "aws-cdk.aws-events-1.122.0.tar.gz", hash = "sha256:28336cb1f9ef4f1c91dd29d5ce488b459384541a79324672bb60d001ed76a9e8"},
-    {file = "aws_cdk.aws_events-1.122.0-py3-none-any.whl", hash = "sha256:d2d091f65a2227483f4f3f2f4f73bf781b948ea211c9e84caaf51852497dfdc4"},
+    {file = "aws-cdk.aws-events-1.130.0.tar.gz", hash = "sha256:6ee24457c50eeda8c9c241596cfa6b123bb50ea2138787fef3e4bb54e4b47f13"},
+    {file = "aws_cdk.aws_events-1.130.0-py3-none-any.whl", hash = "sha256:df91c72843d9734a49017040090b1615be41de020906a57e6c708d860e8a4139"},
 ]
 "aws-cdk.aws-events-targets" = [
-    {file = "aws-cdk.aws-events-targets-1.122.0.tar.gz", hash = "sha256:3064793a601cd7f6a8eb3e4ce266cf3d9eb73c6fb6d2139f5c6656f704030670"},
-    {file = "aws_cdk.aws_events_targets-1.122.0-py3-none-any.whl", hash = "sha256:1f77d32c85b91da919ba9ac6bca2c099960ab2b99896ba25f41742a840983b42"},
+    {file = "aws-cdk.aws-events-targets-1.130.0.tar.gz", hash = "sha256:00cacf2860eea087101926f7166a8fd21ff352dab3848c27f1aa30c6a3ce6e5e"},
+    {file = "aws_cdk.aws_events_targets-1.130.0-py3-none-any.whl", hash = "sha256:c7c2c8639343433f828222fb303305d9fdaa26f4187ecbb38acf7ad0c8387685"},
 ]
 "aws-cdk.aws-globalaccelerator" = [
-    {file = "aws-cdk.aws-globalaccelerator-1.122.0.tar.gz", hash = "sha256:340d22ee00aa930ebbb387364b84bb9d7f8f461054a0158014eaeb05e788cd2b"},
-    {file = "aws_cdk.aws_globalaccelerator-1.122.0-py3-none-any.whl", hash = "sha256:654255fa961c291664479ffe2e1b8555f55500ab3c0f01ecffc23220ae834d57"},
+    {file = "aws-cdk.aws-globalaccelerator-1.130.0.tar.gz", hash = "sha256:78d80daa15aaa0a2d2627cee1d14f42dd4eb1a4d581f1ccdd076c529333de889"},
+    {file = "aws_cdk.aws_globalaccelerator-1.130.0-py3-none-any.whl", hash = "sha256:1eccd713d96a48b2eaa385f4cb1177e3456be597658470e5c8ef2ae570add5bb"},
 ]
 "aws-cdk.aws-iam" = [
-    {file = "aws-cdk.aws-iam-1.122.0.tar.gz", hash = "sha256:775d2a3013e4467141ec4b6434bd27990f623c48b5b51ebec1addec1b9ba6944"},
-    {file = "aws_cdk.aws_iam-1.122.0-py3-none-any.whl", hash = "sha256:f190ed7388b5d46b6435f3e535ea63e5236578a7e312b344cb2555f23a78754f"},
+    {file = "aws-cdk.aws-iam-1.130.0.tar.gz", hash = "sha256:d2bf02a2d3f2bd81c1b9598e7b4424b0dc0d4694b57338d7efac43a89fb6409c"},
+    {file = "aws_cdk.aws_iam-1.130.0-py3-none-any.whl", hash = "sha256:3a3272745da9363177ebd8b138f42ce9407439f909ed9177c226e584022f4ff0"},
 ]
 "aws-cdk.aws-kinesis" = [
-    {file = "aws-cdk.aws-kinesis-1.122.0.tar.gz", hash = "sha256:ce57fbd757dd42088ba44863cc236ccfefb38f8ccf67924029c50dd24db5cdb1"},
-    {file = "aws_cdk.aws_kinesis-1.122.0-py3-none-any.whl", hash = "sha256:55bb5c2bb787c44161073161283318dbd647decd87f504b12f3fa8cec5636109"},
+    {file = "aws-cdk.aws-kinesis-1.130.0.tar.gz", hash = "sha256:9fb61efe81785172d2814313175fb6ad1e77f4b54913346970a458066a2dea78"},
+    {file = "aws_cdk.aws_kinesis-1.130.0-py3-none-any.whl", hash = "sha256:7ebc8355b719c01eedda865a3a954396e5dc6be65c2e9ad2a6a2f81d3ef2ec17"},
 ]
 "aws-cdk.aws-kinesisfirehose" = [
-    {file = "aws-cdk.aws-kinesisfirehose-1.122.0.tar.gz", hash = "sha256:8dd87a079ab28b4094045f8d52fbc00cc6dec8e82341c1486f20f42cd517ccc5"},
-    {file = "aws_cdk.aws_kinesisfirehose-1.122.0-py3-none-any.whl", hash = "sha256:0457b2a4d8ecf4127a6d78c8e8e1b36fd3de709b9d0b383bcf06bf7ae254df0b"},
+    {file = "aws-cdk.aws-kinesisfirehose-1.130.0.tar.gz", hash = "sha256:264e5759ecdbfd1edf2af9ecbc2dce2bc613bc8bd2c0d4b612e172aaa1144a95"},
+    {file = "aws_cdk.aws_kinesisfirehose-1.130.0-py3-none-any.whl", hash = "sha256:12b04627a2165bc3ea995ff614ec3c69191f72fe60d20baf3ab09bcd09a351d9"},
 ]
 "aws-cdk.aws-kms" = [
-    {file = "aws-cdk.aws-kms-1.122.0.tar.gz", hash = "sha256:900da8e6f41bc73565c2136f77bb2f6c25daec10313ddfc6d1cd8ff905d90d43"},
-    {file = "aws_cdk.aws_kms-1.122.0-py3-none-any.whl", hash = "sha256:d9215f202564d765212e4b637192cdb56f6701d13aa2e4e60dcf5f95a6424228"},
+    {file = "aws-cdk.aws-kms-1.130.0.tar.gz", hash = "sha256:1ece4b6753b0271d9164b32c0c94919e2f2a587677b19c554c2a990b5b0803b7"},
+    {file = "aws_cdk.aws_kms-1.130.0-py3-none-any.whl", hash = "sha256:de50127ab5f5f3838b6e4e549696ccfcd2cf18f7edd50616f82b1a0ddcd10075"},
 ]
 "aws-cdk.aws-lambda" = [
-    {file = "aws-cdk.aws-lambda-1.122.0.tar.gz", hash = "sha256:21401c9bb46dfedb8058c717f4c367982b7fe676d27e17ede1d402b7b3e5e1f1"},
-    {file = "aws_cdk.aws_lambda-1.122.0-py3-none-any.whl", hash = "sha256:61230286e0ec729b629d3394680222e32d6df02032f70772982d3d902efb9c78"},
+    {file = "aws-cdk.aws-lambda-1.130.0.tar.gz", hash = "sha256:c3ee7c637f1a590ead83e75803865f58c0c18193ff841d94b0a0b51ea1e9d6fb"},
+    {file = "aws_cdk.aws_lambda-1.130.0-py3-none-any.whl", hash = "sha256:6c8dec3aad5d3900888aab52b0a844d3c05e94f977ff04ec26083302cc76edc8"},
+]
+"aws-cdk.aws-lambda-nodejs" = [
+    {file = "aws-cdk.aws-lambda-nodejs-1.130.0.tar.gz", hash = "sha256:7b07e679233c3addb415acfc397eddc6b9dd678b30282f4ae2ee59c845fb760d"},
+    {file = "aws_cdk.aws_lambda_nodejs-1.130.0-py3-none-any.whl", hash = "sha256:43d05a16101ec1d303857de3a01bde7a5573af45b857157350cf9cb2a785df6f"},
 ]
 "aws-cdk.aws-lambda-python" = [
-    {file = "aws-cdk.aws-lambda-python-1.122.0.tar.gz", hash = "sha256:a62685741a03d8ead5c89f11d66abede226054f4d0d000dc0aff8eb53811c20f"},
-    {file = "aws_cdk.aws_lambda_python-1.122.0-py3-none-any.whl", hash = "sha256:a9c7cb797a2431549a23e917f0089359fbd758d0ae5c11c745ccca1517f2d4d7"},
+    {file = "aws-cdk.aws-lambda-python-1.130.0.tar.gz", hash = "sha256:c6b6a882af68ee64c7bca9ca24d7fe56ffc0b47fcb2ca6fa74921002fe24398a"},
+    {file = "aws_cdk.aws_lambda_python-1.130.0-py3-none-any.whl", hash = "sha256:8165af325872b29744042939a3df62cfefae742606d6165862675fe082b2147a"},
 ]
 "aws-cdk.aws-logs" = [
-    {file = "aws-cdk.aws-logs-1.122.0.tar.gz", hash = "sha256:ef748977cc1a956112b805d8ae99c4256e689efd877d5f25a1b7a1ddec5d915d"},
-    {file = "aws_cdk.aws_logs-1.122.0-py3-none-any.whl", hash = "sha256:340ccec1163cb7108f6da0acce0542b5f96639eea887506d2a2005437d3ccdbb"},
+    {file = "aws-cdk.aws-logs-1.130.0.tar.gz", hash = "sha256:d022ec78f953f1276d710e903ee75857fe86a05b1f44f1610ac4d52b8652ddfc"},
+    {file = "aws_cdk.aws_logs-1.130.0-py3-none-any.whl", hash = "sha256:da8ff0e9ed334bb4bc34cac698ad46ae8e815c7e9018e3754c9a342b84f26bbb"},
 ]
 "aws-cdk.aws-route53" = [
-    {file = "aws-cdk.aws-route53-1.122.0.tar.gz", hash = "sha256:ff149cd277f68a8a38a04d0f942e77fc554fd35d34abd1cbf47b3675e3287112"},
-    {file = "aws_cdk.aws_route53-1.122.0-py3-none-any.whl", hash = "sha256:4dbf1849e91ea0c17adcc241a4ed07a0f0847111f272bdf818806e8601082edc"},
+    {file = "aws-cdk.aws-route53-1.130.0.tar.gz", hash = "sha256:6d1a209505e794922718cbf2f8f432f8d51b305da63ad4f10008b8f1f535f526"},
+    {file = "aws_cdk.aws_route53-1.130.0-py3-none-any.whl", hash = "sha256:270877be4a1469f84c3022300baba2b982cd1644b4ea01d65fb0522adcf9b822"},
 ]
 "aws-cdk.aws-route53-targets" = [
-    {file = "aws-cdk.aws-route53-targets-1.122.0.tar.gz", hash = "sha256:30b50dd2fcc9f90836a59c66afb4f3494d0445c7671c365472940f54f55dc8d9"},
-    {file = "aws_cdk.aws_route53_targets-1.122.0-py3-none-any.whl", hash = "sha256:39060eb0845410976aaffbf90214f00c525b848f4dd46427d83c2847b7aa31f7"},
+    {file = "aws-cdk.aws-route53-targets-1.130.0.tar.gz", hash = "sha256:32bb00910eee2eba3b4a41e86822ede6e44975251c37ebbe9b18b3e20f4f1c38"},
+    {file = "aws_cdk.aws_route53_targets-1.130.0-py3-none-any.whl", hash = "sha256:3608e8666dc0c013be9de579c36ab38f9b5debffbf1d2f788e0559d00f874026"},
 ]
 "aws-cdk.aws-s3" = [
-    {file = "aws-cdk.aws-s3-1.122.0.tar.gz", hash = "sha256:936376e9eb7c5d48d7f57f12250be1654a6f76a7664c1cc71389f096e6a726ba"},
-    {file = "aws_cdk.aws_s3-1.122.0-py3-none-any.whl", hash = "sha256:5a6e7467c1e6d9a3b3adf088518fb5345b4b05d2c2fd6995e4752680b88b1c53"},
+    {file = "aws-cdk.aws-s3-1.130.0.tar.gz", hash = "sha256:940bcb081783937e774cf4f44f77ba7a8211ebe9440cca2d7225b310f4272f79"},
+    {file = "aws_cdk.aws_s3-1.130.0-py3-none-any.whl", hash = "sha256:9fac2a150adf92700c05a02c603d0ff1185894235443980fafc874354c380f52"},
 ]
 "aws-cdk.aws-s3-assets" = [
-    {file = "aws-cdk.aws-s3-assets-1.122.0.tar.gz", hash = "sha256:fbac72e01dcf19730a5ed940d3ae13e63a4c9ac1d555851bd0fb504c57268271"},
-    {file = "aws_cdk.aws_s3_assets-1.122.0-py3-none-any.whl", hash = "sha256:39a8da0ba089658508d6850304dd656a752bb6e62908c37288c62406c27772c6"},
+    {file = "aws-cdk.aws-s3-assets-1.130.0.tar.gz", hash = "sha256:db33b348222895ad14cb9d52d5582b1e80d0e9ff008f8c10ea912499ab7c14f1"},
+    {file = "aws_cdk.aws_s3_assets-1.130.0-py3-none-any.whl", hash = "sha256:01a5b0f2c759a88176929569c6f69d0efb8901452fe112cfd3b3f4782fec12ab"},
 ]
 "aws-cdk.aws-s3-notifications" = [
-    {file = "aws-cdk.aws-s3-notifications-1.122.0.tar.gz", hash = "sha256:f9e300636025c23b308818f9830dbd2462cfd8ae64394561a4cacf7f80eb0fab"},
-    {file = "aws_cdk.aws_s3_notifications-1.122.0-py3-none-any.whl", hash = "sha256:66af56bc7d61f3e01344e83b36cc581172aac67776a51e8df88e2ddfc53b5eec"},
+    {file = "aws-cdk.aws-s3-notifications-1.130.0.tar.gz", hash = "sha256:bb7858a4b61e61b09788f24b10d8c9cbcde84f8f4f9b0b6eb5a8c6a96bc3db51"},
+    {file = "aws_cdk.aws_s3_notifications-1.130.0-py3-none-any.whl", hash = "sha256:23e317c5d2aea59338d2b8223f54c7192de56cad7473c179fb5624215dc92da7"},
 ]
 "aws-cdk.aws-sam" = [
-    {file = "aws-cdk.aws-sam-1.122.0.tar.gz", hash = "sha256:631d06853d63703fa7afaa6b88e6ac7a5035ac2e84ae23e0d823a7eb2093c59b"},
-    {file = "aws_cdk.aws_sam-1.122.0-py3-none-any.whl", hash = "sha256:0fd34f248c6f25c94cb21f912345ce4e62b35ba4d29bcf40b8ca4f4956148633"},
+    {file = "aws-cdk.aws-sam-1.130.0.tar.gz", hash = "sha256:564877af10684b99a76d7ae83b888f9dfc1f7894caed81d5349a059f51430836"},
+    {file = "aws_cdk.aws_sam-1.130.0-py3-none-any.whl", hash = "sha256:dbd38e5e52b5f94aff76bc18640e8ba11ae0d0b183867f747942c753935bf326"},
 ]
 "aws-cdk.aws-secretsmanager" = [
-    {file = "aws-cdk.aws-secretsmanager-1.122.0.tar.gz", hash = "sha256:625fafb79ebf75090a5329400e7de6eeb6cfb7dcc09a2a5063e876a2a9561153"},
-    {file = "aws_cdk.aws_secretsmanager-1.122.0-py3-none-any.whl", hash = "sha256:f65e7fb191a5b7f4cf8df116b30d7969e872bd89eceddff5c014a025bec8ea50"},
+    {file = "aws-cdk.aws-secretsmanager-1.130.0.tar.gz", hash = "sha256:96e52bd3e6523b22f1d60aadeb0b6f435a5276a1ec794e4cfe2294f8ac26259a"},
+    {file = "aws_cdk.aws_secretsmanager-1.130.0-py3-none-any.whl", hash = "sha256:a929ef9fea760b37d5306a1ee9deeecbac2530ab2ea7ec1fc1085544e6af1ca0"},
 ]
 "aws-cdk.aws-servicediscovery" = [
-    {file = "aws-cdk.aws-servicediscovery-1.122.0.tar.gz", hash = "sha256:f89f9bbf8be06cbb416b3be566656e34d302e8c37210fc664ea095fb2466c117"},
-    {file = "aws_cdk.aws_servicediscovery-1.122.0-py3-none-any.whl", hash = "sha256:50ca93f9152fea372b5872b824634ef64d3b57eaddaed072ed5357ec6657b4a3"},
+    {file = "aws-cdk.aws-servicediscovery-1.130.0.tar.gz", hash = "sha256:013d95e2223f4f46f68c88937993eec1c7490ba8ba09a57533e49281096fee79"},
+    {file = "aws_cdk.aws_servicediscovery-1.130.0-py3-none-any.whl", hash = "sha256:17eca0328597178e107a9c0152805a646628aad75026da98849d6ab40eb4fc63"},
 ]
 "aws-cdk.aws-signer" = [
-    {file = "aws-cdk.aws-signer-1.122.0.tar.gz", hash = "sha256:c935ef173bdfc91fe75b198c3d46eac5ee02f0803d0d83cf27c99d626becd34a"},
-    {file = "aws_cdk.aws_signer-1.122.0-py3-none-any.whl", hash = "sha256:ab20a1cdf2ed303a4f3b1a490bcdf3b38e9fb4dd34727d45c469085fe1d4da5e"},
+    {file = "aws-cdk.aws-signer-1.130.0.tar.gz", hash = "sha256:f453d608a491dd0ff7d97fa597f17480d3bf43a0eaedd975e0846bf03de0ab0d"},
+    {file = "aws_cdk.aws_signer-1.130.0-py3-none-any.whl", hash = "sha256:10a5981156c83c8725f565931167b376db24c08d43b325a8ad0e4a10559b32df"},
 ]
 "aws-cdk.aws-sns" = [
-    {file = "aws-cdk.aws-sns-1.122.0.tar.gz", hash = "sha256:483d51e38885dde8c464e8821ef5c8c279093497abe8e82d069b0c791a1e686f"},
-    {file = "aws_cdk.aws_sns-1.122.0-py3-none-any.whl", hash = "sha256:46b15e13eb09854ef567b32c525ccc937848351104febffe4a99a063e6ea208a"},
+    {file = "aws-cdk.aws-sns-1.130.0.tar.gz", hash = "sha256:a2494dd42513b870ef94c0f013e734473fb8a02042b21da5864e3b8bd6609963"},
+    {file = "aws_cdk.aws_sns-1.130.0-py3-none-any.whl", hash = "sha256:7b6dfc5c50cdc0005caac683731772502a9d26d6ef415256f21746bef0b7b444"},
 ]
 "aws-cdk.aws-sns-subscriptions" = [
-    {file = "aws-cdk.aws-sns-subscriptions-1.122.0.tar.gz", hash = "sha256:b9f86b2c33180576c90ad09eacb6127fee18fdf1faa94915d6fe5b4d69db11d8"},
-    {file = "aws_cdk.aws_sns_subscriptions-1.122.0-py3-none-any.whl", hash = "sha256:479336bbd3eed913b8188a9b4ec6670a41c8c313409b32b765b80dd6e13d2093"},
+    {file = "aws-cdk.aws-sns-subscriptions-1.130.0.tar.gz", hash = "sha256:2b26efa9c1e362f5c8418c079033637ca5e3fe6b6c865307e52b2f092f97c862"},
+    {file = "aws_cdk.aws_sns_subscriptions-1.130.0-py3-none-any.whl", hash = "sha256:ebd4ace5a6fae59f10ebc96cb176101ca02f2a6bb3ec8146b94e3b38ad86556c"},
 ]
 "aws-cdk.aws-sqs" = [
-    {file = "aws-cdk.aws-sqs-1.122.0.tar.gz", hash = "sha256:5ed2fa9c7070ebd9de01323416a1e34827d37271b5cf6b6d20a6503fb18acd66"},
-    {file = "aws_cdk.aws_sqs-1.122.0-py3-none-any.whl", hash = "sha256:daf67efd0ae5a09e3b221be7ab776782d50df7baad42b36adf5021e45466edf6"},
+    {file = "aws-cdk.aws-sqs-1.130.0.tar.gz", hash = "sha256:baef9bfc74c33ad5e9ff65a4d48477f68fb503950d58d21e9cc657e8a9914c0f"},
+    {file = "aws_cdk.aws_sqs-1.130.0-py3-none-any.whl", hash = "sha256:bd40f528012fd38398dd7cc6a8c91c62da634e2e620ecfa6530ae43a5d1890b5"},
 ]
 "aws-cdk.aws-ssm" = [
-    {file = "aws-cdk.aws-ssm-1.122.0.tar.gz", hash = "sha256:c7f3888f63a1bc9c1bfa1775f1604421c7dedb40ed4f331ae93856d5696b33f1"},
-    {file = "aws_cdk.aws_ssm-1.122.0-py3-none-any.whl", hash = "sha256:c3b27a3fdf9051fff83d6652aa9cd73cb766d9248aa4aa4f0c99c685ea34bee5"},
+    {file = "aws-cdk.aws-ssm-1.130.0.tar.gz", hash = "sha256:2c0a2e400b82864233e76973020dc16e88afc35aa0ef4dd5250d0404e1236de0"},
+    {file = "aws_cdk.aws_ssm-1.130.0-py3-none-any.whl", hash = "sha256:dd84d306f4794433b921f75081d3db41dfe6fdc6078bfa377a096a1457adc9a9"},
 ]
 "aws-cdk.aws-stepfunctions" = [
-    {file = "aws-cdk.aws-stepfunctions-1.122.0.tar.gz", hash = "sha256:f776499a30b39fe420e44ca7b84dc305034b45c0bd19fa6d8e32b6b24aa6e1d7"},
-    {file = "aws_cdk.aws_stepfunctions-1.122.0-py3-none-any.whl", hash = "sha256:2af95df77e94185a6167ca0e29390ecc9eada0f41d008713d17210e2b6063893"},
+    {file = "aws-cdk.aws-stepfunctions-1.130.0.tar.gz", hash = "sha256:8aee553f96e218ea8f44a9f688f574e6dd21de5e86a6daa3fe57676962430358"},
+    {file = "aws_cdk.aws_stepfunctions-1.130.0-py3-none-any.whl", hash = "sha256:8270e5f05e0b6c7934fedcc221f220e919b6bec9e3af7bf984671b3d6154b23c"},
 ]
 "aws-cdk.aws-stepfunctions-tasks" = [
-    {file = "aws-cdk.aws-stepfunctions-tasks-1.122.0.tar.gz", hash = "sha256:2d3b4c87e9882e5cd49eb7a56700528d261507eaa05717de95ba7616d8aa655b"},
-    {file = "aws_cdk.aws_stepfunctions_tasks-1.122.0-py3-none-any.whl", hash = "sha256:a86e030f1b366a33329d23d69d9ee5487e5cd954ce9a3657581fb7dbcb052ee6"},
+    {file = "aws-cdk.aws-stepfunctions-tasks-1.130.0.tar.gz", hash = "sha256:d5f8d43ea8f29b766a5ad511ad7b070fb4d4df6ffc9720b2984522f41e9695e3"},
+    {file = "aws_cdk.aws_stepfunctions_tasks-1.130.0-py3-none-any.whl", hash = "sha256:4bcd13ab04accabe3acbc1f45d744561eb9ea8d5dda70a5597c73def43c9174d"},
 ]
 "aws-cdk.cloud-assembly-schema" = [
-    {file = "aws-cdk.cloud-assembly-schema-1.122.0.tar.gz", hash = "sha256:c6832b54a1b3bcb7b14786fee6f298b8cb092b853a53d0f23914e3c3f2573888"},
-    {file = "aws_cdk.cloud_assembly_schema-1.122.0-py3-none-any.whl", hash = "sha256:9cc654fc0239b47045b1e4287366bf793e517719e65017b112d9edc868d81c4f"},
+    {file = "aws-cdk.cloud-assembly-schema-1.130.0.tar.gz", hash = "sha256:31231d1fa14037f2af0a0a27657c7e603103c876464868bb8a5731698dba9d7f"},
+    {file = "aws_cdk.cloud_assembly_schema-1.130.0-py3-none-any.whl", hash = "sha256:3eadde99a914ca53e101e66a403b554537435a29e1954cb13e94cdc9305da48a"},
 ]
 "aws-cdk.core" = [
-    {file = "aws-cdk.core-1.122.0.tar.gz", hash = "sha256:4a50eab0a59f11a60fc309efb1a70ae9f987814a55ac071ec7d971765059b903"},
-    {file = "aws_cdk.core-1.122.0-py3-none-any.whl", hash = "sha256:bb64e574e38dffaa7d3c77d02df432822c404f25fcf17e37bd40415772a89524"},
+    {file = "aws-cdk.core-1.130.0.tar.gz", hash = "sha256:d07b98dad35b18481e46b92b6fde7061b76730ac9d1111849db321e519ebdc52"},
+    {file = "aws_cdk.core-1.130.0-py3-none-any.whl", hash = "sha256:7b3f1d0e9f83263763694cfb814346c38984041226180fe298056670fa5a5bd9"},
 ]
 "aws-cdk.custom-resources" = [
-    {file = "aws-cdk.custom-resources-1.122.0.tar.gz", hash = "sha256:386058c8ca39b7467e602457bbb17a4526009aa2c952a638321405534fecb077"},
-    {file = "aws_cdk.custom_resources-1.122.0-py3-none-any.whl", hash = "sha256:f9ba002d4e4ea9ade03eda7a1d5cbfecf1052f5147c948c323ff2fce80135b34"},
+    {file = "aws-cdk.custom-resources-1.130.0.tar.gz", hash = "sha256:c212447b64f79d3605db6e072d23acc6fa1135e5399162a8cd258bc1d22e03e2"},
+    {file = "aws_cdk.custom_resources-1.130.0-py3-none-any.whl", hash = "sha256:07c8a6c99bfe53d251303a7cf50b109fa974ddfd2fdbd22f3e94534271a2f666"},
 ]
 "aws-cdk.cx-api" = [
-    {file = "aws-cdk.cx-api-1.122.0.tar.gz", hash = "sha256:dd5be07165e06f6de106ed13b24fba3d9c85921d278470a068441a270e266fa1"},
-    {file = "aws_cdk.cx_api-1.122.0-py3-none-any.whl", hash = "sha256:c7841f64811e7a0afe0fabe2343e8bbfaaddcfa29885dd5f76e18643918029d3"},
+    {file = "aws-cdk.cx-api-1.130.0.tar.gz", hash = "sha256:3640cdc3c34566bbd0f32fd899fd5ea969d266d0efcd14f67784e557d2c7192c"},
+    {file = "aws_cdk.cx_api-1.130.0-py3-none-any.whl", hash = "sha256:26b425e11e0718f531b6578e0621f141089ec1946ccfa124f929ae932f8340a6"},
 ]
 "aws-cdk.lambda-layer-awscli" = [
-    {file = "aws-cdk.lambda-layer-awscli-1.122.0.tar.gz", hash = "sha256:0b4baa0c15ec3db1745c22f46af4fb938a815f5d0e4b709f2e2168dc153378e0"},
-    {file = "aws_cdk.lambda_layer_awscli-1.122.0-py3-none-any.whl", hash = "sha256:a41df66dfc5dd600dc09315f4ddc596be1c157d0e80cde6f7989952554029252"},
+    {file = "aws-cdk.lambda-layer-awscli-1.130.0.tar.gz", hash = "sha256:b2e531916ac300fbc5ddad5fe2414977b0753e58e744aec6ae7e3025fb3a88f4"},
+    {file = "aws_cdk.lambda_layer_awscli-1.130.0-py3-none-any.whl", hash = "sha256:7f8d32826982f6b4e3ab4d32e1ff44a38af1ad95af8634e8a0b8a86c599141cb"},
 ]
 "aws-cdk.lambda-layer-kubectl" = [
-    {file = "aws-cdk.lambda-layer-kubectl-1.122.0.tar.gz", hash = "sha256:87a9e0e30104b0191e6432c6a17040e389a79b4ebf2d2a8227e4b2a85e15c255"},
-    {file = "aws_cdk.lambda_layer_kubectl-1.122.0-py3-none-any.whl", hash = "sha256:8e31509f87be463e768ec6aa11591f6bc220128cff69e8a85021c5010d8d1ee4"},
+    {file = "aws-cdk.lambda-layer-kubectl-1.130.0.tar.gz", hash = "sha256:4ff1978b20b4c3664ff7a8b69d264dd2797a3c83417e73a6a92396f4de9c38a9"},
+    {file = "aws_cdk.lambda_layer_kubectl-1.130.0-py3-none-any.whl", hash = "sha256:325dbb79a79c50e487bcfcf8463cdd0de64588efaa07e75d86de7c61a426657d"},
+]
+"aws-cdk.lambda-layer-node-proxy-agent" = [
+    {file = "aws-cdk.lambda-layer-node-proxy-agent-1.130.0.tar.gz", hash = "sha256:4d701991d2bb6e2bc53d2607d57b998b4966571b017bf56b2d217c930102691f"},
+    {file = "aws_cdk.lambda_layer_node_proxy_agent-1.130.0-py3-none-any.whl", hash = "sha256:b1816a529966bff77882feeb9050c325198f80955eca1f719cfcd9629fc3f75f"},
 ]
 "aws-cdk.region-info" = [
-    {file = "aws-cdk.region-info-1.122.0.tar.gz", hash = "sha256:2bf7b7a90bab9d281523198dc73302184a43a7aa6e59872f11fdaea768a65dea"},
-    {file = "aws_cdk.region_info-1.122.0-py3-none-any.whl", hash = "sha256:5cab530607be1db24c04c39997ba9438817f22dcb602829888d25bf2406281a7"},
+    {file = "aws-cdk.region-info-1.130.0.tar.gz", hash = "sha256:f5534c3c02cc25215cca2d74aee4dc70cd34b35d86550415a085db65851b135e"},
+    {file = "aws_cdk.region_info-1.130.0-py3-none-any.whl", hash = "sha256:2d4110779dd87f405270bfb31c73f315898698af04ec23b8069cc444d0bd896e"},
 ]
 black = [
     {file = "black-21.9b0-py3-none-any.whl", hash = "sha256:380f1b5da05e5a1429225676655dddb96f5ae8c75bdf91e53d798871b902a115"},
@@ -1818,8 +1858,8 @@ jmespath = [
     {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
 ]
 jsii = [
-    {file = "jsii-1.34.0-py3-none-any.whl", hash = "sha256:d0a703d0d44bf78bb90529699599d2a58a68ca764f996808e97eafc68e2467de"},
-    {file = "jsii-1.34.0.tar.gz", hash = "sha256:e72ba5fafabdd5b6a3a65bd2cf42302eb87f2fe7c6339bddb808226a91623654"},
+    {file = "jsii-1.41.0-py3-none-any.whl", hash = "sha256:b39c1da808d9f32a66d0162a8ad83b38b1e6e1486251d4d1ea1822361d764a26"},
+    {file = "jsii-1.41.0.tar.gz", hash = "sha256:5d312cd7334fb1eae03ef03157231f28542149e01884a7f93ee4cf185c61a29c"},
 ]
 jsonschema = [
     {file = "jsonschema-3.2.0-py2.py3-none-any.whl", hash = "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163"},


### PR DESCRIPTION
**Issue #, if available:** #1

**Description of changes:**

Move splitting of PDFs/TIFFs and rotation of EXIF-tagged images from notebook util to a SageMaker Processing job, to accelerate processing for large corpora via horizontal and vertical scaling.

This involves building a custom container image for the job, since the pre-existing logic depends on `poppler` which can't be just pip installed - otherwise we could have considered using a [FrameworkProcessor](https://sagemaker.readthedocs.io/en/stable/api/training/processing.html#sagemaker.processing.FrameworkProcessor).

The image is built in notebook via `sm-docker`, rather than:
- Using plain `docker` in the notebook, because this command may not be available in SMStudio
- Building and publishing the image in the CDK stack, because this could increase expectation on user's local/build environment and because the CDK [DockerImageAsset](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-ecr-assets.DockerImageAsset.html) currently depends on external resources to publish to a named/non-CDK-internal ECR registry (as discussed in [this issue](https://github.com/aws/aws-cdk/issues/12597))

We use the `sm-docker` CLI to build the image in the notebook because plain `docker` may not be available in SMStudio. 

**Testing done:**

Redeployed CDK stack in (not quite fresh) environment, cleared out relevant S3 folders and checked data preparation still runs okay.


<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
