### PR TITLE
Support image files in notebook 1 data prep

### DIFF
--- a/notebooks/1. Data Preparation.ipynb
+++ b/notebooks/1. Data Preparation.ipynb
@@ -82,7 +82,7 @@
     "\n",
     "# External Dependencies:\n",
     "import boto3  # AWS SDK for Python\n",
-    "from IPython.display import HTML  # To display rich content in notebook\n",
+    "from IPython import display  # To display rich content in notebook\n",
     "import pandas as pd  # For tabular data analysis\n",
     "import sagemaker  # High-level SDK for SageMaker\n",
     "from tqdm.notebook import tqdm  # Progress bars\n",
@@ -238,11 +238,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "HTML(\n",
-    "    '<iframe src=\"{}\" width=100% height=600 type=\"application/pdf\"></iframe>'.format(\n",
-    "        # Edit the below (e.g. 0, 1, 2) to see different documents:\n",
-    "        \"data/raw/\" + rel_filepaths[0]\n",
-    "    )\n",
+    "display.IFrame(\n",
+    "    # Edit the below (e.g. 0, 1, 2) to see different documents:\n",
+    "    \"data/raw/\" + rel_filepaths[0],\n",
+    "    height=\"600\",\n",
+    "    width=\"100%\",\n",
     ")"
    ]
   },


### PR DESCRIPTION
Update the build_data_manifest utility to support single-page image
format documents, for which the pdf2image_regex isn't applicable to
look up cleaned images in S3 from input file.

**Issue #, if available:** #5

**Description of changes:**

Update/fix the `build_data_manifest` utility function to support single-page image format documents.

Previously, this function assumed the `pdf2image_regex` was applicable to all input documents: But the preprocessing job outputs don't match this format when input raw documents are single images (e.g. PNG, JPEG) or multi-page images (e.g. TIFF). This resulted in errors failing to build collated `textract-ref` + `source-ref` manifests for custom corpora including non-PDF documents.

**Testing done:**

Initially tested with synthetic corpus - exploring additional tests to verify the fix

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
