### PR TITLE
Training Compiler and larger instance fixes

### DIFF
--- a/notebooks/2. Model Training.ipynb
+++ b/notebooks/2. Model Training.ipynb
@@ -37,7 +37,7 @@
     "# External Dependencies:\n",
     "import boto3  # AWS SDK for Python\n",
     "import sagemaker\n",
-    "from sagemaker.huggingface import HuggingFace as HuggingFaceEstimator\n",
+    "from sagemaker.huggingface import HuggingFace as HuggingFaceEstimator, TrainingCompilerConfig\n",
     "from tqdm.notebook import tqdm  # Progress bars\n",
     "\n",
     "# Local Dependencies:\n",
@@ -428,7 +428,7 @@
     "    \"textract_prefix\": textract_s3uri[len(\"s3://\"):].partition(\"/\")[2],\n",
     "\n",
     "    \"model_name_or_path\": \"microsoft/layoutlm-base-uncased\",\n",
-    "    \n",
+    "\n",
     "    \"learning_rate\": 5e-5,\n",
     "    \"per_device_train_batch_size\": 4,\n",
     "\n",
@@ -462,7 +462,7 @@
     "    pytorch_version=\"1.9\",\n",
     "    transformers_version=\"4.11\",\n",
     "\n",
-    "    base_job_name=\"layoutlm-cfpb-pretrain\",\n",
+    "    base_job_name=\"llm-cfpb-pretrain\",\n",
     "    output_path=f\"s3://{bucket_name}/{bucket_prefix}trainjobs\",\n",
     "\n",
     "    instance_type=\"ml.p3.8xlarge\",\n",
@@ -504,6 +504,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "If you're interested to explore [SageMaker Training Compiler](https://docs.aws.amazon.com/sagemaker/latest/dg/training-compiler.html) to optimize training of this model, check out the additional guidance in [src/smtc_launcher.py](src/smtc_launcher.py)\n",
+    "\n",
     "Once the pre-training is complete, fetch the output model S3 URI to use as input for the fine-tuning stage:"
    ]
   },
@@ -628,7 +630,7 @@
     "    pytorch_version=\"1.9\",\n",
     "    transformers_version=\"4.11\",\n",
     "\n",
-    "    base_job_name=\"layoutlm-cfpb-hf\",\n",
+    "    base_job_name=\"llm-cfpb-hf\",\n",
     "    output_path=f\"s3://{bucket_name}/{bucket_prefix}trainjobs\",\n",
     "    #checkpoint_s3_uri=checkpoint_s3_uri,  # Un-comment to turn on checkpoint upload to S3\n",
     "\n",
@@ -699,7 +701,7 @@
     "tuner = sagemaker.tuner.HyperparameterTuner(\n",
     "    estimator,\n",
     "    \"validation:target\",\n",
-    "    base_tuning_job_name=\"layoutlm-cfpb-hpo\",\n",
+    "    base_tuning_job_name=\"llm-cfpb-hpo\",\n",
     "    hyperparameter_ranges={\n",
     "        \"learning_rate\": sagemaker.parameter.ContinuousParameter(\n",
     "            1e-8,\n",
@@ -717,7 +719,7 @@
     "    #early_stopping_type=\"Auto\",  # Off by default - could consider turning it on\n",
     "#     warm_start_config=sagemaker.tuner.WarmStartConfig(\n",
     "#         warm_start_type=sagemaker.tuner.WarmStartTypes.IDENTICAL_DATA_AND_ALGORITHM,\n",
-    "#         parents={ \"layoutlm-cfpb-hpo-210723-1625\" },\n",
+    "#         parents={ \"llm-cfpb-hpo-210723-1625\" },\n",
     "#     ),\n",
     ")\n",
     "\n",
@@ -756,8 +758,8 @@
    "outputs": [],
    "source": [
     "# If needed, you can attach to a previous training job by name like this:\n",
-    "# estimator = HuggingFaceEstimator.attach(\"layoutlm-cfpb-210529-0851-006-5ee95cde\")\n",
-    "# tuner = sagemaker.tuner.HyperparameterTuner.attach(\"layoutlm-cfpb-hpo-210603-0542\")"
+    "# estimator = HuggingFaceEstimator.attach(\"llm-cfpb-210529-0851-006-5ee95cde\")\n",
+    "# tuner = sagemaker.tuner.HyperparameterTuner.attach(\"llm-cfpb-hpo-210603-0542\")"
    ]
   },
   {
@@ -1059,7 +1061,7 @@
     "# As with estimators, you can attach the notebook to a previously deployed endpoint like this:\n",
     "# from sagemaker.huggingface import HuggingFacePredictor\n",
     "# predictor = HuggingFacePredictor(\n",
-    "#     \"layoutlm-cfpb-hf-2021-09-02-01-08-11-234\",\n",
+    "#     \"llm-cfpb-hf-2021-09-02-01-08-11-234\",\n",
     "#     serializer=sagemaker.serializers.JSONSerializer(),\n",
     "#     deserializer=sagemaker.deserializers.JSONDeserializer(),\n",
     "# )"

--- a/notebooks/src/smtc_launcher.py
+++ b/notebooks/src/smtc_launcher.py
@@ -1,0 +1,76 @@
+#!/bin/python
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Alternative train launcher script for SageMaker Training Compiler
+
+More info at: https://docs.aws.amazon.com/sagemaker/latest/dg/training-compiler-enable.html
+
+To use SMTC, you'll need to specify a `compiler_config` and set the "GPU_NUM_DEVICES" environment
+variable on your Estimator to the number of GPUs per instance for the type you have selected. For
+example:
+
+```python
+from sagemaker.huggingface import TrainingCompilerConfig
+
+pre_estimator = HuggingFaceEstimator(
+    ...,
+    compiler_config=TrainingCompilerConfig(),
+    env={
+        ...,
+        "GPU_NUM_DEVICES": "4",  # for ml.p3.8xlarge
+    },
+)
+```
+
+For single-GPU training, you can use the train.py entry_point as usual. However for multi-GPU
+training, you'll need to instead set this `entry_point="smtc_launcher.py"` and add an additional
+hyperparameter `"training_script": "train.py"`.
+
+This training script has been tested to *functionally* work with SMTC (on Hugging Face v4.11 DLC),
+but whether you'll see a useful speed-up may be quite hyperparameter- and use-case-dependent. Note
+that a substantial portion of the optimization opportunity with SMTC comes from memory efficiency
+allowing larger batch sizes.
+
+Remember also that on p3.16xl and larger where it's supported, enabling SageMaker Distributed Data
+Parallel can provide a useful speed boost. When *neither* SMTC nor SMDistributed are enabled, the
+HF Trainer API will use PyTorch DataParallel by default (rather than DistributedDataParallel) which
+can limit scaling to many GPUs - partly because memory consumption is higher on the "lead" GPU and
+so CUDAOutOfMemory will be encountered at lower maximum batch sizes.
+
+Notes from pre-training experiments
+-----------------------------------
+
+2,500 document training set (set N_DOCS_KEPT = 2500 in notebook 1) on `ml.p3.8xlarge`, pre-training
+with:
+
+- num_train_epochs = 25
+- early_stopping_patience = 10
+- per_device_eval_batch_size = per_device_train_batch_size
+- seed = 42
+- warmup_steps = 200
+
+| SMTC | per_device_train_batch_size | learning_rate |      Execution Time  | min val loss |
+|:----:|----------------------------:|--------------:|---------------------:|-------------:|
+|   No |                          4  |        5e-05  | 5h28m16s (25 epochs) |    0.149301  |
+|   No |                          8  |        2e-05  | 4h13m46s (25 epochs) |    0.154481  |
+|  Yes |                         20  |        2e-05  |       N/A (GPU OOM)  |   N/A (OOM)  |
+|  Yes |                         16  |        1e-04  | 5h03m03s (25 epochs) |    0.147910  |
+|  Yes |                         16  |        5e-05  | 5h05m03s (25 epochs) |    0.141911  |
+|  Yes |                         16  |        2e-05  | 5h02m52s (25 epochs) |    0.159771  |
+|  Yes |                         16  |        1e-05  | 5h01m09s (25 epochs) |    0.191195  |
+|  Yes |                         16  |        5e-06  | 5h01m48s (25 epochs) |    0.249820  |
+|  Yes |                         12  |        1e-05  | 5h10m35s (25 epochs) |    0.165622  |
+|  Yes |                          8  |        2e-05  | 2h50m02s (12 epochs) |  * 0.301963  |
+|  Yes |                          8  |        1e-05  | 2h37m52s (11 epochs) |  * 0.627447  |
+
+(*): Training unstable and stopped early after reaching `nan` loss. Best epoch reported.
+"""
+# Python Built-Ins:
+import subprocess
+import sys
+
+if __name__ == "__main__":
+    arguments_command = " ".join([arg for arg in sys.argv[1:]])
+    subprocess.check_call(
+        "python -m torch_xla.distributed.sm_dist " + arguments_command, shell=True
+    )

--- a/notebooks/src/train.py
+++ b/notebooks/src/train.py
@@ -8,9 +8,8 @@ import os
 import sys
 
 
-if __name__ == "__main__":
-    # If the file is running as a script, we're in training mode and should run the actual training
-    # routine (with a little logging setup before any imports, to make sure output shows up ok):
+def run_training():
+    """Configure logging, import local modules and run the training job"""
     consolehandler = logging.StreamHandler(sys.stdout)
     consolehandler.setFormatter(
         logging.Formatter("%(asctime)s [%(name)s] %(levelname)s %(message)s")
@@ -19,7 +18,13 @@ if __name__ == "__main__":
 
     from code.train import main
 
-    main()
+    return main()
+
+
+if __name__ == "__main__":
+    # If the file is running as a script, we're in training mode and should run the actual training
+    # routine (with a little logging setup before any imports, to make sure output shows up ok):
+    run_training()
 else:
     # If the file is imported as a module, we're in inference mode and should pass through the
     # override functions defined in the inference module. This is to support directly deploying the
@@ -27,3 +32,11 @@ else:
     # SAGEMAKER_PROGRAM=train.py from training - causing the server to try and load handlers from
     # here rather than inference.py.
     from code.inference import *
+
+
+def _mp_fn(index):
+    """For torch_xla / SageMaker Training Compiler
+
+    (See smtc_launcher.py in this folder for configuration tips)
+    """
+    return run_training()


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

- Modify the training entrypoint to (functionally) work with [SageMaker Training Compiler](https://docs.aws.amazon.com/sagemaker/latest/dg/training-compiler.html) for single- and multi-GPU.
- Fix default `dataloader_num_workers` scaling for better results with large instances (e.g. p3.16xl, where the num_workers previously caused CUDAOutOfMemory unless SMDistributed is enabled) or SMTC (where the large num_workers was causing RAM exhaustion before GPU memory exhaustion with increasing batch size).
- Add notes from initial tests with SMTC and link from notebook 2 to instructions for optionally enabling it.
- Shorten training job names 'layoutlm'->'llm' in notebook 2, to better accommodate adding extra specifiers to the names for experiments.

**Testing done:**

Still in-progress. So far SMTC tested with pre-training only.

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
