### PR TITLE
Update focus_acc computation to discards invalid examples from the average

### DIFF
--- a/notebooks/2. Model Training.ipynb
+++ b/notebooks/2. Model Training.ipynb
@@ -616,6 +616,7 @@
     "    { \"Name\": \"validation:n_examples\", \"Regex\": get_hf_metric_regex(\"eval_n_examples\") },\n",
     "    { \"Name\": \"validation:loss_avg\", \"Regex\": get_hf_metric_regex(\"eval_loss\") },\n",
     "    { \"Name\": \"validation:acc\", \"Regex\": get_hf_metric_regex(\"eval_acc\") },\n",
+    "    { \"Name\": \"validation:n_focus_examples\", \"Regex\": get_hf_metric_regex(\"eval_n_focus_examples\") },\n",
     "    { \"Name\": \"validation:focus_acc\", \"Regex\": get_hf_metric_regex(\"eval_focus_acc\") },\n",
     "    { \"Name\": \"validation:target\", \"Regex\": get_hf_metric_regex(\"eval_focus_else_acc_minus_one\") },\n",
     "]\n",

--- a/notebooks/src/code/data/ner.py
+++ b/notebooks/src/code/data/ner.py
@@ -463,10 +463,14 @@ def get_metric_computer(
         )
         n_examples = probs_raw.shape[0]
         acc = acc_by_example.sum() / n_examples
-        focus_acc = focus_acc_by_example.sum() / n_examples
+        
+        n_focus_examples = n_focus_tokens_by_example[n_focus_tokens_by_example != 0].shape[0]
+        focus_acc = focus_acc_by_example.sum() / n_focus_examples
+
         return {
             "n_examples": n_examples,
             "acc": acc,
+            "n_focus_examples": n_focus_examples,
             "focus_acc": focus_acc,
             # By nature of the metric, focus_acc can sometimes take a few epochs to move away from
             # 0.0. Since acc and focus_acc are both 0-1, we can define this metric to show early


### PR DESCRIPTION
**Description of changes:**
While working with the solution and delving into the details of how the `focus_acc` metric is computed for model validation, I realised that there are situations when examples do not contain any focus tokens, but are still "captured" in this metric. 

Although these examples are excluded from the focus token sums (i.e. `focus_acc_by_example` - line 451 from `ner.py`), when the focus_acc_by_example` is averaged into `focus_acc`, the total number of validation examples is used (`n_examples = probs_raw.shape[0]`) instead of the `n_focus_tokens_by_example` elements that are not 0. 

By nature of the `focus_acc`, I understand that this metric only accounts for non-default labelled or predicted tokens, hence I concluded that it should not take into consideration examples where there are no such tokens. So I am proposing this change. @athewsey, I look forward to finding out your POV on this.

Additionally, the PR also introduces the `n_focus_examples` metric that will be captured in CloudWatch.

**Testing done:**
Solution execution with and without the change - analysis of the metrics via CloudWatch.

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
