### PR TITLE
Update attp-bootstrap.cfn.yaml

### DIFF
--- a/.infrastructure/attp-bootstrap.cfn.yaml
+++ b/.infrastructure/attp-bootstrap.cfn.yaml
@@ -84,7 +84,7 @@ Resources:
             pre_build:
               commands:
                 - set -ex
-                - curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+                - curl -sSL https://install.python-poetry.org | python -
                 - export PATH="/root/.local/bin:$PATH"
                 - npm install -g aws-cdk
             build:


### PR DESCRIPTION
This part of the build project the url used to install the poetry is invalid, so i updated in my project. the error that shows with the default url installation: [Container] 2023/06/21 21:23:31 Running command set -ex
+ CODEBUILD_LAST_EXIT=0
+ export -p
+ pwd
+ exit 0

[Container] 2023/06/21 21:23:31 Running command curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
  File "<stdin>", line 1
    404: Not Found
    ^
SyntaxError: illegal target for annotation

[Container] 2023/06/21 21:23:33 Command did not exit successfully curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python - exit status 1 [Container] 2023/06/21 21:23:33 Phase complete: PRE_BUILD State: FAILED [Container] 2023/06/21 21:23:33 Phase context status code: COMMAND_EXECUTION_ERROR Message: Error while executing command: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -. Reason: exit status 1

**Issue #, if available:**

**Description of changes:**

**Testing done:**


<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
